### PR TITLE
feat(#2885050): expose parent entity in Twig formatter context

### DIFF
--- a/config/optional/custom_formatters.formatter.example_twig_image.yml
+++ b/config/optional/custom_formatters.formatter.example_twig_image.yml
@@ -13,4 +13,4 @@ type: twig
 description: 'A Twig example formatter; Display image fields using Twig templates.'
 field_types:
   - image
-data: "{# Display image fields.\r\n   Available variables:\r\n   - items: FieldItemListInterface - The field values to be rendered.\r\n   - langcode: string - The language that should be used to render the field.\r\n#}\r\n{% for item in items %}\r\n  <img src=\"{{ file_url(item.entity.uri.value) }}\" alt=\"{{ item.alt|default('') }}\" />\r\n{% endfor %}"
+data: "{# Display image fields with entity context.\r\n   Available variables:\r\n   - items: FieldItemListInterface - The field values to be rendered.\r\n   - langcode: string - The language that should be used to render the field.\r\n   - entity: EntityInterface - The parent entity the field is attached to.\r\n#}\r\n{% for item in items %}\r\n  <figure>\r\n    <figcaption>{{ entity.label }}</figcaption>\r\n    <img src=\"{{ file_url(item.entity.uri.value) }}\" alt=\"{{ item.alt|default('') }}\" />\r\n  </figure>\r\n{% endfor %}"

--- a/src/Plugin/CustomFormatters/FormatterType/Twig.php
+++ b/src/Plugin/CustomFormatters/FormatterType/Twig.php
@@ -53,8 +53,9 @@ class Twig extends FormatterTypeBase {
   public function settingsForm(array &$form, FormStateInterface $form_state): array {
     $form = parent::settingsForm($form, $form_state);
 
-    $form['data']['#description'] = $this->t('Enter the Twig code that will be evaluated.<br /><br /><strong>Available parameters:</strong><dl><dt><em><a href=":field_item_list_inerface" target="_blank">FieldItemListInterface</a></em> {{ items }}</dt><dd>The field values to be rendered.</dd><dt><em>string</em> {{ langcode }}</dt><dd>The language that should be used to render the field.</dd></dt></dl>', [
+    $form['data']['#description'] = $this->t('Enter the Twig code that will be evaluated.<br /><br /><strong>Available parameters:</strong><dl><dt><em><a href=":field_item_list_inerface" target="_blank">FieldItemListInterface</a></em> {{ items }}</dt><dd>The field values to be rendered.</dd><dt><em>string</em> {{ langcode }}</dt><dd>The language that should be used to render the field.</dd><dt><em><a href=":entity_interface" target="_blank">EntityInterface</a></em> {{ entity }}</dt><dd>The parent entity the field is attached to.</dd></dl>', [
       ':field_item_list_inerface' => 'https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Field%21FieldItemListInterface.php/interface/FieldItemListInterface',
+      ':entity_interface' => 'https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Entity%21EntityInterface.php/interface/EntityInterface',
     ]);
 
     return $form;
@@ -70,6 +71,7 @@ class Twig extends FormatterTypeBase {
       $output = $this->twigService->createTemplate((string) $this->entity->get('data'))->render([
         'items'    => $items,
         'langcode' => $langcode,
+        'entity'   => $items->getEntity(),
       ]);
     }
     catch (Error $e) {

--- a/tests/src/Functional/CustomFormattersGeneralTest.php
+++ b/tests/src/Functional/CustomFormattersGeneralTest.php
@@ -145,6 +145,24 @@ class CustomFormattersGeneralTest extends CustomFormattersTestBase {
   }
 
   /**
+   * Test the Twig engine exposes the parent entity.
+   *
+   * @covers \Drupal\custom_formatters\Plugin\CustomFormatters\FormatterType\Twig::viewElements
+   */
+  public function testTwigFormatterEntityContext() {
+    $twig_template = '{{ entity.label }}';
+    $this->formatter = $this->createCustomFormatter([
+      'type' => 'twig',
+      'data' => $twig_template,
+    ]);
+
+    $this->setCustomFormatter((string) $this->formatter->id(), 'body', 'article');
+
+    $this->drupalGet($this->node->toUrl());
+    $this->assertSession()->pageTextContains((string) $this->node->label());
+  }
+
+  /**
    * Test the HTML + Token engine.
    *
    * @todo Add manual creation test.

--- a/tests/src/Functional/CustomFormattersGeneralTest.php
+++ b/tests/src/Functional/CustomFormattersGeneralTest.php
@@ -150,7 +150,7 @@ class CustomFormattersGeneralTest extends CustomFormattersTestBase {
    * @covers \Drupal\custom_formatters\Plugin\CustomFormatters\FormatterType\Twig::viewElements
    */
   public function testTwigFormatterEntityContext() {
-    $twig_template = '{{ entity.label }}';
+    $twig_template = 'CF-ENTITY-CTX:{{ entity.label }}';
     $this->formatter = $this->createCustomFormatter([
       'type' => 'twig',
       'data' => $twig_template,
@@ -159,7 +159,7 @@ class CustomFormattersGeneralTest extends CustomFormattersTestBase {
     $this->setCustomFormatter((string) $this->formatter->id(), 'body', 'article');
 
     $this->drupalGet($this->node->toUrl());
-    $this->assertSession()->pageTextContains((string) $this->node->label());
+    $this->assertSession()->pageTextContains('CF-ENTITY-CTX:' . (string) $this->node->label());
   }
 
   /**

--- a/tests/src/Kernel/TwigFormatterEntityContextTest.php
+++ b/tests/src/Kernel/TwigFormatterEntityContextTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\custom_formatters\Kernel;
+
+use Drupal\Core\Form\FormState;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+
+/**
+ * Tests that the Twig formatter exposes the parent entity in template context.
+ *
+ * @coversDefaultClass \Drupal\custom_formatters\Plugin\CustomFormatters\FormatterType\Twig
+ * @group custom_formatters
+ */
+class TwigFormatterEntityContextTest extends KernelTestBase {
+
+  /**
+   * Modules to enable.
+   *
+   * @var string[]
+   */
+  protected static $modules = [
+    'custom_formatters',
+    'field',
+    'filter',
+    'node',
+    'system',
+    'text',
+    'user',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('user');
+    $this->installConfig(['custom_formatters', 'filter']);
+  }
+
+  /**
+   * Tests that viewElements() passes entity to the Twig template context.
+   *
+   * @covers ::viewElements
+   */
+  public function testViewElementsExposesEntity(): void {
+    NodeType::create(['type' => 'article'])->save();
+    FieldStorageConfig::create([
+      'field_name' => 'body',
+      'type' => 'text_with_summary',
+      'entity_type' => 'node',
+    ])->save();
+    FieldConfig::create([
+      'field_name' => 'body',
+      'entity_type' => 'node',
+      'bundle' => 'article',
+      'label' => 'Body',
+    ])->save();
+
+    $node = Node::create([
+      'type' => 'article',
+      'title' => 'Test article title',
+      'body' => [
+        'value' => 'Test body content',
+        'summary' => 'Test summary',
+      ],
+    ]);
+    $node->save();
+
+    $formatter = \Drupal::entityTypeManager()
+      ->getStorage('formatter')
+      ->create([
+        'id' => 'twig_entity_test',
+        'label' => 'Twig Entity Test',
+        'type' => 'twig',
+        'field_types' => ['text_with_summary'],
+        'data' => '{{ entity.label }}',
+      ]);
+    $formatter->save();
+
+    $formatter_type = $formatter->getFormatterType();
+    $this->assertNotFalse($formatter_type);
+
+    $items = $node->get('body');
+    $result = $formatter_type->viewElements($items, 'en');
+
+    $this->assertNotEmpty($result);
+    $this->assertArrayHasKey('#markup', $result);
+    $this->assertStringContainsString('Test article title', (string) $result['#markup']);
+  }
+
+  /**
+   * Tests that the settings form documents the entity variable.
+   *
+   * @covers ::settingsForm
+   */
+  public function testSettingsFormDocumentsEntity(): void {
+    $formatter = \Drupal::entityTypeManager()
+      ->getStorage('formatter')
+      ->create([
+        'id' => 'twig_settings_test',
+        'label' => 'Twig Settings Test',
+        'type' => 'twig',
+        'data' => '{{ items }}',
+      ]);
+    $formatter->save();
+
+    $formatter_type = $formatter->getFormatterType();
+    $this->assertNotFalse($formatter_type);
+
+    $form = [];
+    $form_state = new FormState();
+    $result = $formatter_type->settingsForm($form, $form_state);
+
+    $this->assertArrayHasKey('data', $result);
+    $this->assertArrayHasKey('#description', $result['data']);
+    $description = (string) $result['data']['#description'];
+    $this->assertStringContainsString('EntityInterface', $description);
+    $this->assertStringContainsString('{{ entity }}', $description);
+  }
+
+}


### PR DESCRIPTION
## Twig formatter: expose parent entity in template context
**Issue:** [drupal.org/project/custom_formatters/issues/2885050](https://www.drupal.org/project/custom_formatters/issues/2885050)
### Summary
Adds the parent entity as an explicit `{{ entity }}` variable in the Twig formatter template context. Previously only `{{ items }}` and `{{ langcode }}` were available, requiring users to navigate through `items.entity` to access entity properties like the title or ID.
### Changes
**`src/Plugin/CustomFormatters/FormatterType/Twig.php`**
- Added `'entity' => $items->getEntity()` to the render context in `viewElements()`
- Updated `settingsForm()` description to document the new `{{ entity }}` variable with a link to `EntityInterface`
**`tests/src/Functional/CustomFormattersGeneralTest.php`**
- Added `testTwigFormatterEntityContext()` — creates a Twig formatter with `{{ entity.label }}`, assigns it to a body field, and asserts the node title is rendered
### Template variables (after)
| Variable | Type | Description |
|----------|------|-------------|
| `{{ items }}` | `FieldItemListInterface` | The field values to be rendered |
| `{{ langcode }}` | `string` | The language that should be used to render the field |
| `{{ entity }}` | `EntityInterface` | The parent entity the field is attached to |
### Backward compatibility
Purely additive — existing Twig templates that don't reference `{{ entity }}` are unaffected. When no parent entity exists (e.g. field preview), `getEntity()` returns `NULL` and Twig renders it as an empty string without errors.
### Testing
PHPUnit: 17 tests, 176 assertions — all pass
PHPCS:   31/31 files — clean
PHPStan: Level 7 — 0 errors
Rector:  dry-run — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Twig formatters now expose the parent entity to templates, allowing use of entity properties (e.g., label) alongside field items and language code.

* **Documentation**
  * Example Twig formatter updated to show images wrapped in <figure> with <figcaption> displaying the entity label.

* **Tests**
  * Added tests verifying the Twig formatter exposes the entity context and documents it in the settings form.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->