### PR TITLE
fix(#3387578): align route parameter with entity type ID

### DIFF
--- a/src/Entity/Formatter.php
+++ b/src/Entity/Formatter.php
@@ -45,8 +45,8 @@ use Drupal\custom_formatters\FormatterInterface;
  *     "data",
  *   },
  *   links = {
- *     "delete-form" = "/admin/structure/formatters/manage/{custom_formatter}/delete",
- *     "edit-form" = "/admin/structure/formatters/manage/{custom_formatter}",
+ *     "delete-form" = "/admin/structure/formatters/manage/{formatter}/delete",
+ *     "edit-form" = "/admin/structure/formatters/manage/{formatter}",
  *     "collection" = "/admin/structure/formatters",
  *   }
  * )

--- a/tests/src/Kernel/FormatterRouteParameterTest.php
+++ b/tests/src/Kernel/FormatterRouteParameterTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @file
+ * Kernel tests for formatter entity route parameter alignment.
+ */
+
+namespace Drupal\Tests\custom_formatters\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Tests that Formatter entity route parameters match the entity type ID.
+ *
+ * Regression test for issue #3387578 - MissingMandatoryParametersException
+ * when Devel module generates entity.formatter.devel_load route, because
+ * the entity links used {custom_formatter} instead of {formatter}.
+ *
+ * @group custom_formatters
+ */
+class FormatterRouteParameterTest extends KernelTestBase {
+
+  /**
+   * Modules to enable.
+   *
+   * @var string[]
+   */
+  protected static $modules = ['custom_formatters'];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installConfig('custom_formatters');
+  }
+
+  /**
+   * Test that entity link URLs generate correctly with the entity type ID.
+   */
+  public function testRouteParameterMatchesEntityTypeId(): void {
+    $formatter = \Drupal::entityTypeManager()
+      ->getStorage('formatter')
+      ->create([
+        'id' => 'test_route_param',
+        'label' => 'Test Route Param',
+        'type' => 'html_token',
+        'field_types' => ['text'],
+      ]);
+    $formatter->save();
+
+    $edit_url = $formatter->toUrl('edit-form')->toString(TRUE)->getGeneratedUrl();
+    $this->assertEquals('/admin/structure/formatters/manage/test_route_param', $edit_url);
+
+    $delete_url = $formatter->toUrl('delete-form')->toString(TRUE)->getGeneratedUrl();
+    $this->assertEquals('/admin/structure/formatters/manage/test_route_param/delete', $delete_url);
+
+    $collection_url = $formatter->toUrl('collection')->toString(TRUE)->getGeneratedUrl();
+    $this->assertEquals('/admin/structure/formatters', $collection_url);
+  }
+
+  /**
+   * Test that entity link templates use the entity type ID as parameter.
+   */
+  public function testLinkTemplatesUseEntityTypeIdParameter(): void {
+    $entity_type = \Drupal::entityTypeManager()->getDefinition('formatter');
+    $links = $entity_type->get('links');
+
+    foreach (['edit-form', 'delete-form'] as $link_key) {
+      $this->assertArrayHasKey($link_key, $links);
+      $this->assertStringContainsString('{formatter}', $links[$link_key],
+        "Link template '{$link_key}' must use {formatter} parameter."
+      );
+      $this->assertStringNotContainsString('{custom_formatter}', $links[$link_key],
+        "Link template '{$link_key}' must NOT use {custom_formatter} parameter."
+      );
+    }
+  }
+
+}


### PR DESCRIPTION
The issue was a mismatch between the entity type ID (`formatter`) and the route parameter name used in the entity links (`{custom_formatter}`). The Devel module generates routes using the entity type ID as the parameter name, which conflicted with our custom parameter name.
I've updated the route parameter to `{formatter}` to match the entity type ID, which is the standard Drupal convention. This changes the admin URL path slightly but since these are admin-only routes, the impact is minimal.
### Changes
- `delete-form`: `/admin/structure/formatters/manage/{custom_formatter}/delete` → `/admin/structure/formatters/manage/{formatter}/delete`
- `edit-form`: `/admin/structure/formatters/manage/{custom_formatter}` → `/admin/structure/formatters/manage/{formatter}`
### Testing
- Installed Devel module — no `MissingMandatoryParametersException`
- Created a formatter and verified edit/delete links work with the new URL pattern
- All 19 automated tests pass (185 assertions)
- Added `FormatterRouteParameterTest` kernel test to prevent regression

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Admin edit and delete links for formatters now generate correct admin URLs so management actions resolve reliably.

* **Tests**
  * Added kernel tests to verify admin URL generation and link templates for formatter management to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->