### PR TITLE
Add Save & Edit button to formatter edit form

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ TODOs / Roadmap
 * Add custom support for admin theme / Formatter add page.
 * Add ability to change field types that aren't in use.
 * Set usages of formatters to default formatter on deletion.
-* Re-add save & edit?
+* ~~Re-add save & edit?~~ (Added in 4.1.x)
 * Re-add preview.
   - Replace EditArea with a modern code editor (CodeMirror, Monaco Editor).
 * Re-add export?

--- a/src/Form/FormatterForm.php
+++ b/src/Form/FormatterForm.php
@@ -247,7 +247,7 @@ class FormatterForm extends EntityForm {
     $actions['save_and_edit'] = [
       '#type' => 'submit',
       '#value' => $this->t('Save & Edit'),
-      '#submit' => ['::saveAndEdit'],
+      '#submit' => ['::submitForm', '::saveAndEdit'],
       '#weight' => 10,
     ];
     return $actions;
@@ -258,6 +258,7 @@ class FormatterForm extends EntityForm {
    */
   public function saveAndEdit(array $form, FormStateInterface $form_state) {
     $this->save($form, $form_state);
+    $form_state->setIgnoreDestination(TRUE);
     $form_state->setRedirectUrl($this->entity->toUrl('edit-form'));
   }
 

--- a/src/Form/FormatterForm.php
+++ b/src/Form/FormatterForm.php
@@ -242,6 +242,28 @@ class FormatterForm extends EntityForm {
   /**
    * {@inheritdoc}
    */
+  protected function actions(array $form, FormStateInterface $form_state) {
+    $actions = parent::actions($form, $form_state);
+    $actions['save_and_edit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Save & Edit'),
+      '#submit' => ['::saveAndEdit'],
+      '#weight' => 10,
+    ];
+    return $actions;
+  }
+
+  /**
+   * Submit handler for "Save & Edit" button.
+   */
+  public function saveAndEdit(array $form, FormStateInterface $form_state) {
+    $this->save($form, $form_state);
+    $form_state->setRedirectUrl($this->entity->toUrl('edit-form'));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function save(array $form, FormStateInterface $form_state) {
     $formatter_type = $this->entity->getFormatterType();
     if ($formatter_type !== FALSE) {

--- a/tests/src/Functional/CustomFormattersGeneralTest.php
+++ b/tests/src/Functional/CustomFormattersGeneralTest.php
@@ -229,6 +229,7 @@ class CustomFormattersGeneralTest extends CustomFormattersTestBase {
     $formatter = $this->createCustomFormatter([
       'type' => 'html_token',
       'label' => 'Save And Edit Test',
+      'data' => '[node:title]',
     ]);
 
     $this->drupalGet('admin/structure/formatters/manage/' . $formatter->id());
@@ -241,6 +242,10 @@ class CustomFormattersGeneralTest extends CustomFormattersTestBase {
 
     $this->assertSession()->addressEquals('admin/structure/formatters/manage/' . $formatter->id());
     $this->assertSession()->fieldValueEquals('label', 'Save And Edit Test Updated');
+
+    $reloaded = \Drupal::entityTypeManager()->getStorage('formatter')->load($formatter->id());
+    $this->assertEquals('Save And Edit Test Updated', $reloaded->label(),
+      'Updated label must be persisted in storage after Save & Edit.');
   }
 
   /**
@@ -270,6 +275,7 @@ class CustomFormattersGeneralTest extends CustomFormattersTestBase {
     $formatter = $this->createCustomFormatter([
       'type' => 'html_token',
       'label' => 'Collection Redirect Test',
+      'data' => '[node:title]',
     ]);
 
     $this->drupalGet('admin/structure/formatters/manage/' . $formatter->id());
@@ -280,11 +286,11 @@ class CustomFormattersGeneralTest extends CustomFormattersTestBase {
     ];
     $this->submitForm($edit, 'Save');
 
-    $current_url = $this->getUrl();
-    $this->assertTrue(
-      strpos($current_url, 'admin/structure/formatters') !== FALSE,
-      'Redirected to collection page, current URL: ' . $current_url
-    );
+    $edit_path = 'admin/structure/formatters/manage/' . $formatter->id();
+    $this->assertStringNotContainsString($edit_path, $this->getUrl(),
+      'Default Save should redirect away from the edit form.');
+    $this->assertStringContainsString('admin/structure/formatters', $this->getUrl(),
+      'Default Save should redirect within the formatters admin section.');
   }
 
   /**

--- a/tests/src/Functional/CustomFormattersGeneralTest.php
+++ b/tests/src/Functional/CustomFormattersGeneralTest.php
@@ -208,6 +208,83 @@ class CustomFormattersGeneralTest extends CustomFormattersTestBase {
     $this->assertSession()->statusCodeEquals(200);
     $this->assertSession()->fieldExists('label');
     $this->assertSession()->fieldExists('type');
+    $this->assertSession()->buttonExists('Save & Edit');
+    $this->assertSession()->buttonExists('Save');
+  }
+
+  /**
+   * Test that formatter add page shows Save & Edit button after type selection.
+   */
+  public function testFormatterAddPageHasSaveAndEditButton() {
+    $this->drupalGet('admin/structure/formatters/add/html_token');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->buttonExists('Save & Edit');
+    $this->assertSession()->buttonExists('Save');
+  }
+
+  /**
+   * Test Save & Edit redirects to edit form for existing formatter.
+   */
+  public function testSaveAndEditExistingFormatterRedirectsToEdit() {
+    $formatter = $this->createCustomFormatter([
+      'type' => 'html_token',
+      'label' => 'Save And Edit Test',
+    ]);
+
+    $this->drupalGet('admin/structure/formatters/manage/' . $formatter->id());
+    $this->assertSession()->statusCodeEquals(200);
+
+    $edit = [
+      'label' => 'Save And Edit Test Updated',
+    ];
+    $this->submitForm($edit, 'Save & Edit');
+
+    $this->assertSession()->addressEquals('admin/structure/formatters/manage/' . $formatter->id());
+    $this->assertSession()->fieldValueEquals('label', 'Save And Edit Test Updated');
+  }
+
+  /**
+   * Test Save & Edit creates new formatter and redirects to its edit form.
+   */
+  public function testSaveAndEditNewFormatterRedirectsToEdit() {
+    $this->drupalGet('admin/structure/formatters/add/html_token');
+    $this->assertSession()->statusCodeEquals(200);
+
+    $formatter_id = mb_strtolower($this->randomMachineName());
+    $edit = [
+      'label' => 'New Formatter From Save And Edit',
+      'id' => $formatter_id,
+      'field_types' => 'text',
+      'data' => '[node:title]',
+    ];
+    $this->submitForm($edit, 'Save & Edit');
+
+    $this->assertSession()->addressEquals('admin/structure/formatters/manage/' . $formatter_id);
+    $this->assertSession()->pageTextContains('Added formatter New Formatter From Save And Edit.');
+  }
+
+  /**
+   * Test default Save button redirects to collection page.
+   */
+  public function testDefaultSaveRedirectsToCollection() {
+    $formatter = $this->createCustomFormatter([
+      'type' => 'html_token',
+      'label' => 'Collection Redirect Test',
+    ]);
+
+    $this->drupalGet('admin/structure/formatters/manage/' . $formatter->id());
+    $this->assertSession()->statusCodeEquals(200);
+
+    $edit = [
+      'label' => 'Collection Redirect Test Updated',
+    ];
+    $this->submitForm($edit, 'Save');
+
+    $current_url = $this->getUrl();
+    $this->assertTrue(
+      strpos($current_url, 'admin/structure/formatters') !== FALSE,
+      'Redirected to collection page, current URL: ' . $current_url
+    );
   }
 
   /**

--- a/tests/src/Kernel/FormatterFormTest.php
+++ b/tests/src/Kernel/FormatterFormTest.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @file
+ * Kernel tests for the Save & Edit functionality in FormatterForm.
+ */
+
+namespace Drupal\Tests\custom_formatters\Kernel;
+
+use Drupal\Core\Form\FormState;
+use Drupal\custom_formatters\Form\FormatterForm;
+use Drupal\custom_formatters\FormatterInterface;
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Tests the Save & Edit button on the formatter entity form.
+ *
+ * Verifies that the "Save & Edit" button is present in the form actions,
+ * includes the correct submit handler chain, redirects to the edit form
+ * for both new and existing formatters, and ignores the ?destination
+ * query parameter that Drupal adds when navigating from the collection page.
+ *
+ * These tests run as kernel tests (not functional) to ensure code coverage
+ * is collected, since functional tests execute form submissions via HTTP
+ * to a separate PHP process where pcov cannot track coverage.
+ *
+ * @see \Drupal\custom_formatters\Form\FormatterForm::actions()
+ * @see \Drupal\custom_formatters\Form\FormatterForm::saveAndEdit()
+ *
+ * @group custom_formatters
+ */
+class FormatterFormTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['custom_formatters', 'field', 'system', 'user'];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installConfig('custom_formatters');
+  }
+
+  /**
+   * Tests that the form actions contain both Save and Save & Edit buttons.
+   *
+   * Verifies that the Save & Edit button exists, has the correct label,
+   * and includes both ::submitForm and ::saveAndEdit in its #submit
+   * handler chain, following the standard Drupal entity form pattern.
+   */
+  public function testActionsContainsSaveAndEditButton(): void {
+    $formatter = $this->createFormatter('test_actions');
+    $formatter->save();
+
+    $form_object = \Drupal::entityTypeManager()
+      ->getFormObject('formatter', 'edit');
+    $form_object->setEntity($formatter);
+
+    $form = \Drupal::formBuilder()->getForm($form_object);
+
+    $this->assertArrayHasKey('submit', $form['actions']);
+    $this->assertArrayHasKey('save_and_edit', $form['actions']);
+    $this->assertSame('Save & Edit', (string) $form['actions']['save_and_edit']['#value']);
+    $this->assertContains('::submitForm', $form['actions']['save_and_edit']['#submit']);
+    $this->assertContains('::saveAndEdit', $form['actions']['save_and_edit']['#submit']);
+  }
+
+  /**
+   * Tests Save & Edit on an existing formatter redirects to the edit form.
+   *
+   * Creates a formatter, submits updated values via Save & Edit, then
+   * verifies that the redirect targets the edit form route with the
+   * correct formatter parameter, that destination override is disabled,
+   * and that the updated label is persisted in storage.
+   */
+  public function testSaveAndEditExistingFormatterRedirectsToEditForm(): void {
+    $formatter = $this->createFormatter('test_existing');
+    $formatter->save();
+
+    $form_object = \Drupal::entityTypeManager()
+      ->getFormObject('formatter', 'edit');
+    assert($form_object instanceof FormatterForm);
+    $form_object->setEntity($formatter);
+
+    $form = \Drupal::formBuilder()->getForm($form_object);
+    $form_state = new FormState();
+    $form_state->setValues([
+      'label' => 'Updated Label',
+      'id' => 'test_existing',
+      'type' => 'html_token',
+      'status' => TRUE,
+      'description' => '',
+      'field_types' => 'text',
+      'data' => '[node:title]',
+    ]);
+
+    $form_object->submitForm($form, $form_state);
+    $form_object->saveAndEdit($form, $form_state);
+
+    $redirect = $form_state->getRedirect();
+    $this->assertNotNull($redirect);
+    $this->assertEquals('entity.formatter.edit_form', $redirect->getRouteName());
+    $this->assertEquals('test_existing', $redirect->getRouteParameters()['formatter']);
+    $this->assertTrue($form_state->getIgnoreDestination());
+
+    $reloaded = \Drupal::entityTypeManager()
+      ->getStorage('formatter')
+      ->load('test_existing');
+    $this->assertEquals('Updated Label', $reloaded->label());
+  }
+
+  /**
+   * Tests Save & Edit on a new formatter creates it and redirects to edit.
+   *
+   * Creates an unsaved formatter entity, submits via Save & Edit, then
+   * verifies that the redirect targets the new entity's edit form and
+   * that destination override is disabled.
+   */
+  public function testSaveAndEditNewFormatterRedirectsToEditForm(): void {
+    $formatter = $this->createFormatter('test_new');
+
+    $form_object = \Drupal::entityTypeManager()
+      ->getFormObject('formatter', 'default');
+    assert($form_object instanceof FormatterForm);
+    $form_object->setEntity($formatter);
+
+    $form = \Drupal::formBuilder()->getForm($form_object);
+    $form_state = new FormState();
+    $form_state->setValues([
+      'label' => 'New Formatter',
+      'id' => 'test_new',
+      'type' => 'html_token',
+      'status' => TRUE,
+      'description' => '',
+      'field_types' => 'text',
+      'data' => '[node:title]',
+    ]);
+
+    $form_object->submitForm($form, $form_state);
+    $form_object->saveAndEdit($form, $form_state);
+
+    $redirect = $form_state->getRedirect();
+    $this->assertNotNull($redirect);
+    $this->assertEquals('entity.formatter.edit_form', $redirect->getRouteName());
+    $this->assertEquals('test_new', $redirect->getRouteParameters()['formatter']);
+    $this->assertTrue($form_state->getIgnoreDestination());
+  }
+
+  /**
+   * Creates a formatter entity with basic properties.
+   *
+   * @param string $id
+   *   The formatter machine name.
+   *
+   * @return \Drupal\custom_formatters\FormatterInterface
+   *   The unsaved formatter entity.
+   */
+  private function createFormatter(string $id): FormatterInterface {
+    $formatter = \Drupal::entityTypeManager()
+      ->getStorage('formatter')
+      ->create([
+        'id' => $id,
+        'label' => 'Test ' . $id,
+        'type' => 'html_token',
+        'field_types' => ['string'],
+        'data' => '[node:title]',
+      ]);
+    assert($formatter instanceof FormatterInterface);
+    return $formatter;
+  }
+
+}


### PR DESCRIPTION
Re-adds the "Save & Edit" button to the Custom Formatters formatter entity
edit form. This feature was present in the Drupal 7 version but was removed
during the D8 port.
## Changes
### FormatterForm.php
- Added `actions()` method to add "Save & Edit" submit button alongside "Save"
- Added `saveAndEdit()` submit handler that saves then redirects to edit form
- New formatter: redirects to new entity's edit form
- Existing formatter: redirects back to same edit form
### CustomFormattersGeneralTest.php
- `testFormatterEditPageLoads`: Verify both buttons exist on edit form
- `testFormatterAddPageHasSaveAndEditButton`: Verify buttons on add form  
- `testSaveAndEditExistingFormatterRedirectsToEdit`: Confirm redirect on edit
- `testSaveAndEditNewFormatterRedirectsToEdit`: Confirm redirect after create
- `testDefaultSaveRedirectsToCollection`: Confirm existing Save unchanged
### README.md
- Marked "Re-add save & edit?" as complete (4.1.x)
## Testing
```bash
DRUPAL_VERSION=10 make test-functional
# OK (17 tests, 190 assertions)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Re-added "Save & Edit" button for formatters, enabling users to save changes and remain on the edit form for continued editing.

* **Tests**
  * Added comprehensive functional test coverage for "Save & Edit" and "Save" button behaviors across formatter create and edit workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->