### PR TITLE
fix(#3025496): suppress contextual links in non-HTML request formats

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -42,6 +42,7 @@ parameters:
         - web/modules/custom/custom_formatters/src/FormatterTypeBase.php
         - web/modules/custom/custom_formatters/src/Plugin/Derivative/CustomFormatters.php
         - web/modules/custom/custom_formatters/src/Plugin/Field/FieldFormatter/CustomFormatters.php
+        - web/modules/custom/custom_formatters/src/Plugin/CustomFormatters/FormatterExtras/Contextual.php
         - web/modules/custom/custom_formatters/src/Plugin/CustomFormatters/FormatterType/*
       reportUnmatched: false
 

--- a/src/Plugin/CustomFormatters/FormatterExtras/Contextual.php
+++ b/src/Plugin/CustomFormatters/FormatterExtras/Contextual.php
@@ -10,7 +10,10 @@ declare(strict_types=1);
 namespace Drupal\custom_formatters\Plugin\CustomFormatters\FormatterExtras;
 
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\custom_formatters\FormatterExtrasBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 define('CUSTOM_FORMATTERS_EXTRAS_CONTEXTUAL_DISABLED', 0);
 define('CUSTOM_FORMATTERS_EXTRAS_CONTEXTUAL_ENABLED', 1);
@@ -29,7 +32,34 @@ define('CUSTOM_FORMATTERS_EXTRAS_CONTEXTUAL_ENABLED', 1);
  *   }
  * )
  */
-class Contextual extends FormatterExtrasBase {
+class Contextual extends FormatterExtrasBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The request stack.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected $requestStack;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, RequestStack $request_stack) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->requestStack = $request_stack;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('request_stack'),
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -61,7 +91,8 @@ class Contextual extends FormatterExtrasBase {
    * {@inheritdoc}
    */
   public function formatterViewElementsAlter(array &$element) {
-    if ($this->entity->getThirdPartySetting('contextual', 'mode', CUSTOM_FORMATTERS_EXTRAS_CONTEXTUAL_ENABLED) == CUSTOM_FORMATTERS_EXTRAS_CONTEXTUAL_ENABLED) {
+    $request_format = $this->requestStack->getCurrentRequest()?->getRequestFormat() ?? 'html';
+    if ($request_format === 'html' && $this->entity->getThirdPartySetting('contextual', 'mode', CUSTOM_FORMATTERS_EXTRAS_CONTEXTUAL_ENABLED) == CUSTOM_FORMATTERS_EXTRAS_CONTEXTUAL_ENABLED) {
       // Wrap the first element in a container so contextual links can be added
       // as a sibling without overwriting the formatter's render output.
       $element[0] = ['markup' => $element[0]];

--- a/tests/src/Kernel/ContextualExportTest.php
+++ b/tests/src/Kernel/ContextualExportTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @file
+ * Kernel tests for contextual links suppression in non-HTML request formats.
+ */
+
+namespace Drupal\Tests\custom_formatters\Kernel;
+
+use Drupal\custom_formatters\FormatterInterface;
+use Drupal\custom_formatters\Plugin\CustomFormatters\FormatterExtras\Contextual;
+use Drupal\KernelTests\KernelTestBase;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Tests that contextual link placeholders are suppressed in non-HTML formats.
+ *
+ * Verifies that the Contextual extras plugin only adds contextual link
+ * placeholders when the current request format is HTML, preventing raw
+ * placeholder markup from leaking into CSV/JSON exports.
+ *
+ * @group custom_formatters
+ */
+class ContextualExportTest extends KernelTestBase {
+
+  /**
+   * Modules to enable.
+   *
+   * @var string[]
+   */
+  protected static $modules = ['custom_formatters', 'field', 'system', 'user', 'contextual'];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installConfig('custom_formatters');
+  }
+
+  /**
+   * Tests that contextual links are added when request format is HTML.
+   */
+  public function testContextualLinksPresentInHtmlFormat(): void {
+    $formatter = \Drupal::entityTypeManager()
+      ->getStorage('formatter')
+      ->create([
+        'id' => 'test_contextual_html',
+        'label' => 'Test Contextual HTML',
+        'type' => 'html_token',
+        'field_types' => ['string'],
+        'data' => '[node:title]',
+      ]);
+    assert($formatter instanceof FormatterInterface);
+    $formatter->save();
+
+    $request_stack = \Drupal::requestStack();
+    $request = Request::create('/');
+    $request->setRequestFormat('html');
+    $request_stack->push($request);
+
+    try {
+      $plugin = $this->createContextualPlugin($formatter);
+      $element = [['#markup' => 'test output']];
+      $plugin->formatterViewElementsAlter($element);
+
+      $this->assertArrayHasKey('contextual_links', $element[0]);
+      $this->assertEquals('contextual_links_placeholder', $element[0]['contextual_links']['#type']);
+    }
+    finally {
+      $request_stack->pop();
+    }
+  }
+
+  /**
+   * Tests that contextual links are suppressed in non-HTML request formats.
+   */
+  public function testContextualLinksSuppressedInNonHtmlFormat(): void {
+    $formatter = \Drupal::entityTypeManager()
+      ->getStorage('formatter')
+      ->create([
+        'id' => 'test_contextual_csv',
+        'label' => 'Test Contextual CSV',
+        'type' => 'html_token',
+        'field_types' => ['string'],
+        'data' => '[node:title]',
+      ]);
+    assert($formatter instanceof FormatterInterface);
+    $formatter->save();
+
+    $request_stack = \Drupal::requestStack();
+    $request = Request::create('/');
+    $request->setRequestFormat('csv');
+    $request_stack->push($request);
+
+    try {
+      $plugin = $this->createContextualPlugin($formatter);
+      $element = [['#markup' => 'test output']];
+      $plugin->formatterViewElementsAlter($element);
+
+      $this->assertArrayNotHasKey('contextual_links', $element[0]);
+      $this->assertEquals('test output', $element[0]['#markup']);
+    }
+    finally {
+      $request_stack->pop();
+    }
+  }
+
+  /**
+   * Creates a Contextual extras plugin instance for testing.
+   */
+  private function createContextualPlugin(FormatterInterface $formatter): Contextual {
+    return Contextual::create(
+      \Drupal::getContainer(),
+      ['entity' => $formatter],
+      'contextual',
+      [
+        'id' => 'contextual',
+        'label' => 'Contextual links',
+        'description' => 'Behaviour for Contextual links integration.',
+        'dependencies' => ['module' => ['contextual']],
+      ],
+    );
+  }
+
+}


### PR DESCRIPTION
## Summary
The Contextual extras plugin was adding contextual link placeholders to formatter output regardless of request format. When custom formatters are used in non-HTML contexts (Views CSV/JSON exports, REST responses), the placeholders aren't processed and appear as raw markup in the exported data.
## Changes
- Added request format check to `Contextual::formatterViewElementsAlter()` — contextual links are now only injected when the request format is `html`
- Refactored Contextual plugin to use `ContainerFactoryPluginInterface` with injected `RequestStack` (dependency injection instead of `\Drupal` static call)
- Added kernel test `ContextualExportTest` with coverage for both HTML and non-HTML formats
- Updated `phpstan.neon` baseline for the new `new static()` pattern
## Testing
- 30 automated tests pass (272 assertions)
- PHPStan + PHPCS clean
- Manually verified: JSON export is clean, HTML page still shows contextual links
Fixes https://www.drupal.org/project/custom_formatters/issues/3025496

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed contextual links appearing in non-HTML formats such as CSV exports. Contextual links now only display when viewing content in HTML format.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Decipher/custom_formatters/pull/9?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->