### PR TITLE
feat: add live preview with per-engine debug options to formatter edit form

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "drupal/token": "^1"
     },
     "suggest": {
-        "drupal/token": "Provides token replacement support for the HTML Token formatter type.",
-        "drupal/codemirror_editor": "Provides syntax-highlighted code editing via CodeMirror for the PHP, HTML+Token, and Twig formatter engines."
+        "drupal/codemirror_editor": "Provides syntax-highlighted code editing via CodeMirror for the PHP, HTML+Token, and Twig formatter engines.",
+        "drupal/devel": "Provides debug output options for the preview feature and Devel Generate integration for generating sample preview content.",
+        "drupal/token": "Provides token replacement support for the HTML Token formatter type."
     }
 }

--- a/custom_formatters.libraries.yml
+++ b/custom_formatters.libraries.yml
@@ -3,3 +3,5 @@ formatter_form:
   css:
     component:
       styles/custom_formatters.css: {}
+  dependencies:
+    - core/claro

--- a/custom_formatters.libraries.yml
+++ b/custom_formatters.libraries.yml
@@ -1,0 +1,5 @@
+formatter_form:
+  version: VERSION
+  css:
+    component:
+      styles/custom_formatters.css: {}

--- a/custom_formatters.module
+++ b/custom_formatters.module
@@ -51,6 +51,11 @@ function custom_formatters_theme() {
     'variables' => ['content' => NULL],
   ];
 
+  $themes['formatter_preview'] = [
+    'variables' => ['content' => NULL],
+    'template'  => 'formatter-preview',
+  ];
+
   return $themes;
 }
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -117,4 +117,11 @@ parameters:
         - web/modules/custom/custom_formatters/src/Form/FormatterForm.php
       reportUnmatched: false
 
+    -
+      # Optional Devel service - method calls on untyped service object
+      message: '#Call to an undefined method object::exportAsRenderable#'
+      paths:
+        - web/modules/custom/custom_formatters/src/Form/FormatterForm.php
+      reportUnmatched: false
+
   reportUnmatchedIgnoredErrors: false

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -121,11 +121,4 @@ parameters:
         - web/modules/custom/custom_formatters/src/FormatterTypeBase.php
       reportUnmatched: false
 
-    -
-      # Optional Devel service - method calls on untyped service object
-      message: '#Call to an undefined method object::exportAsRenderable#'
-      paths:
-        - web/modules/custom/custom_formatters/src/Form/FormatterForm.php
-      reportUnmatched: false
-
   reportUnmatchedIgnoredErrors: false

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -58,6 +58,7 @@ parameters:
       message: '#no value type specified in iterable type.*FieldItemListInterface#'
       paths:
         - web/modules/custom/custom_formatters/src/Plugin/CustomFormatters/FormatterType/*
+        - web/modules/custom/custom_formatters/src/Form/FormatterForm.php
       reportUnmatched: false
 
     -
@@ -98,6 +99,7 @@ parameters:
       paths:
         - web/modules/custom/custom_formatters/src/Plugin/CustomFormatters/FormatterType/*
         - web/modules/custom/custom_formatters/src/FormatterTypeInterface.php
+        - web/modules/custom/custom_formatters/src/Form/FormatterForm.php
       reportUnmatched: false
 
     -
@@ -112,6 +114,7 @@ parameters:
       message: '#has parameter \$items with generic interface.*FieldItemListInterface but does not specify its types#'
       paths:
         - web/modules/custom/custom_formatters/src/Plugin/CustomFormatters/FormatterType/*
+        - web/modules/custom/custom_formatters/src/Form/FormatterForm.php
       reportUnmatched: false
 
   reportUnmatchedIgnoredErrors: false

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -58,6 +58,8 @@ parameters:
       message: '#no value type specified in iterable type.*FieldItemListInterface#'
       paths:
         - web/modules/custom/custom_formatters/src/Plugin/CustomFormatters/FormatterType/*
+        - web/modules/custom/custom_formatters/src/FormatterTypeInterface.php
+        - web/modules/custom/custom_formatters/src/FormatterTypeBase.php
         - web/modules/custom/custom_formatters/src/Form/FormatterForm.php
       reportUnmatched: false
 
@@ -100,6 +102,7 @@ parameters:
         - web/modules/custom/custom_formatters/src/Plugin/CustomFormatters/FormatterType/*
         - web/modules/custom/custom_formatters/src/FormatterTypeInterface.php
         - web/modules/custom/custom_formatters/src/Form/FormatterForm.php
+        - web/modules/custom/custom_formatters/src/FormatterTypeBase.php
       reportUnmatched: false
 
     -
@@ -115,6 +118,7 @@ parameters:
       paths:
         - web/modules/custom/custom_formatters/src/Plugin/CustomFormatters/FormatterType/*
         - web/modules/custom/custom_formatters/src/Form/FormatterForm.php
+        - web/modules/custom/custom_formatters/src/FormatterTypeBase.php
       reportUnmatched: false
 
     -

--- a/src/Form/FormatterForm.php
+++ b/src/Form/FormatterForm.php
@@ -9,13 +9,20 @@ declare(strict_types=1);
 
 namespace Drupal\custom_formatters\Form;
 
+use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Entity\EntityForm;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
+use Drupal\Core\Entity\FieldableEntityInterface;
+use Drupal\Core\Field\FieldConfigInterface;
+use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Field\FieldTypePluginManagerInterface;
 use Drupal\Core\Field\FormatterPluginManager;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\RendererInterface;
 use Drupal\Core\Url;
+use Drupal\custom_formatters\Entity\Formatter;
 use Drupal\custom_formatters\FormatterExtrasManager;
+use Drupal\custom_formatters\FormatterTypeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -52,6 +59,20 @@ class FormatterForm extends EntityForm {
   protected $fieldTypeManager;
 
   /**
+   * The entity field manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityFieldManagerInterface
+   */
+  protected $entityFieldManager;
+
+  /**
+   * The entity type bundle info service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeBundleInfoInterface
+   */
+  protected $entityTypeBundleInfo;
+
+  /**
    * The renderer service.
    *
    * @var \Drupal\Core\Render\RendererInterface
@@ -67,13 +88,19 @@ class FormatterForm extends EntityForm {
    *   The field formatter plugin manager.
    * @param \Drupal\Core\Field\FieldTypePluginManagerInterface $field_type_manager
    *   The field type plugin manager.
+   * @param \Drupal\Core\Entity\EntityFieldManagerInterface $entity_field_manager
+   *   The entity field manager service.
+   * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entity_type_bundle_info
+   *   The entity type bundle info service.
    * @param \Drupal\Core\Render\RendererInterface $renderer
    *   The renderer service.
    */
-  public function __construct(FormatterExtrasManager $formatter_extras_manager, FormatterPluginManager $field_formatter_manager, FieldTypePluginManagerInterface $field_type_manager, RendererInterface $renderer) {
+  public function __construct(FormatterExtrasManager $formatter_extras_manager, FormatterPluginManager $field_formatter_manager, FieldTypePluginManagerInterface $field_type_manager, EntityFieldManagerInterface $entity_field_manager, EntityTypeBundleInfoInterface $entity_type_bundle_info, RendererInterface $renderer) {
     $this->formatterExtrasManager = $formatter_extras_manager;
     $this->fieldTypeManager = $field_type_manager;
     $this->fieldFormatterManager = $field_formatter_manager;
+    $this->entityFieldManager = $entity_field_manager;
+    $this->entityTypeBundleInfo = $entity_type_bundle_info;
     $this->renderer = $renderer;
   }
 
@@ -85,6 +112,8 @@ class FormatterForm extends EntityForm {
       $container->get('plugin.manager.custom_formatters.formatter_extras'),
       $container->get('plugin.manager.field.formatter'),
       $container->get('plugin.manager.field.field_type'),
+      $container->get('entity_field.manager'),
+      $container->get('entity_type.bundle.info'),
       $container->get('renderer')
     );
   }
@@ -101,6 +130,8 @@ class FormatterForm extends EntityForm {
     }
 
     $form = parent::form($form, $form_state);
+
+    $form['#attached']['library'][] = 'custom_formatters/formatter_form';
 
     // Show warning if formatter is currently in use.
     $dependent_entities = $this->entity->getDependentEntities();
@@ -178,20 +209,567 @@ class FormatterForm extends EntityForm {
     $form['plugin']['#prefix'] = "<div id='plugin-wrapper'>";
     $form['plugin']['#suffix'] = "</div>";
 
+    // Extras vertical tabs group — always rendered so preview tab can join.
+    $form['vertical_tabs'] = [
+      '#type'    => 'vertical_tabs',
+      '#title'   => $this->t('Extras'),
+      '#parents' => ['extras'],
+    ];
+
+    // Preview section.
+    $form['preview'] = $this->buildPreviewFieldset($form, $form_state);
+
     // Third party integration settings form.
     $extras = $this->getFormatterExtrasForm();
     if ($extras && is_array($extras)) {
-      $form['vertical_tabs'] = [
-        '#type'    => 'vertical_tabs',
-        '#title'   => $this->t('Extras'),
-        '#parents' => ['extras'],
-      ];
-
       $form['extras'] = $extras;
       $form['extras']['#tree'] = TRUE;
     }
 
     return $form;
+  }
+
+  /**
+   * Builds the preview fieldset.
+   *
+   * @param array $form
+   *   The form array.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   *
+   * @return array
+   *   The preview fieldset render array.
+   */
+  protected function buildPreviewFieldset(array $form, FormStateInterface $form_state): array {
+    $fieldset = [
+      '#type'   => 'details',
+      '#title'  => $this->t('Preview'),
+      '#group'  => 'extras',
+      '#weight' => -10,
+      '#tree'   => TRUE,
+    ];
+
+    $defaults = $this->getPreviewDefaults($form_state);
+    $entity_type_id = $form_state->getValue(['preview', 'selects', 'entity_type']) ?? $defaults['entity_type'];
+    $bundle = $form_state->getValue(['preview', 'selects', 'bundle']) ?? $defaults['bundle'];
+    $field_name = $form_state->getValue(['preview', 'selects', 'field']) ?? $defaults['field'];
+    $entity_id = $form_state->getValue(['preview', 'selects', 'entity']) ?? $defaults['entity'];
+
+    $entity_type_options = $this->getPreviewEntityTypes();
+    if (!isset($entity_type_options[$entity_type_id])) {
+      $entity_type_id = key($entity_type_options) ?: NULL;
+      $bundle = NULL;
+      $field_name = NULL;
+      $entity_id = NULL;
+    }
+
+    $bundle_options = $entity_type_id ? $this->getPreviewBundles($entity_type_id) : [];
+    if ($bundle !== NULL && !isset($bundle_options[$bundle])) {
+      $bundle = key($bundle_options) ?: NULL;
+      $field_name = NULL;
+      $entity_id = NULL;
+    }
+
+    $field_types = (array) ($form_state->getValue('field_types') ?? $this->entity->get('field_types'));
+    $field_options = ($entity_type_id && $bundle) ? $this->getPreviewFields($entity_type_id, $bundle, $field_types) : [];
+    if ($field_name !== NULL && !isset($field_options[$field_name])) {
+      $field_name = key($field_options) ?: NULL;
+      $entity_id = NULL;
+    }
+
+    $entity_options = ($entity_type_id && $bundle && $field_name) ? $this->getPreviewEntities($entity_type_id, $bundle, $field_name) : [];
+    if ($entity_id !== NULL && !isset($entity_options[$entity_id])) {
+      $entity_id = key($entity_options) ?: NULL;
+    }
+
+    $fieldset['selects'] = [
+      '#type'       => 'container',
+      '#attributes' => ['class' => ['preview-selects-row']],
+      '#prefix'     => '<div id="preview-selects-wrapper">',
+      '#suffix'     => '</div>',
+    ];
+
+    $fieldset['selects']['entity_type'] = [
+      '#type'          => 'select',
+      '#title'         => $this->t('Entity type'),
+      '#options'       => $entity_type_options,
+      '#default_value' => $entity_type_id,
+      '#empty_option'  => $this->t('- Select -'),
+      '#ajax'          => [
+        'callback' => '::previewSelectsAjax',
+        'wrapper'  => 'preview-selects-wrapper',
+      ],
+    ];
+
+    $fieldset['selects']['bundle'] = [
+      '#type'          => 'select',
+      '#title'         => $this->t('Bundle'),
+      '#options'       => $bundle_options,
+      '#default_value' => $bundle,
+      '#empty_option'  => $this->t('- Select -'),
+      '#validated'     => TRUE,
+      '#ajax'          => [
+        'callback' => '::previewSelectsAjax',
+        'wrapper'  => 'preview-selects-wrapper',
+      ],
+    ];
+
+    $fieldset['selects']['field'] = [
+      '#type'          => 'select',
+      '#title'         => $this->t('Field'),
+      '#options'       => $field_options,
+      '#default_value' => $field_name,
+      '#empty_option'  => $this->t('- Select -'),
+      '#validated'     => TRUE,
+      '#ajax'          => [
+        'callback' => '::previewSelectsAjax',
+        'wrapper'  => 'preview-selects-wrapper',
+      ],
+    ];
+
+    $fieldset['selects']['entity'] = [
+      '#type'          => 'select',
+      '#title'         => $this->t('Entity'),
+      '#options'       => $entity_options,
+      '#default_value' => $entity_id,
+      '#empty_option'  => $this->t('- Select -'),
+      '#validated'     => TRUE,
+    ];
+
+    $formatter_type = $this->entity->getFormatterType();
+
+    $fieldset['settings'] = [
+      '#type'       => 'container',
+      '#attributes' => ['class' => ['preview-settings-row']],
+    ];
+
+    if ($formatter_type) {
+      foreach ($formatter_type->previewSettingsForm() as $key => $element) {
+        $fieldset['settings'][$key] = $element;
+      }
+    }
+
+    $fieldset['settings']['toggle'] = [
+      '#type'          => 'checkbox',
+      '#title'         => $this->t('Show full field theming'),
+      '#default_value' => $form_state->getValue(['preview', 'settings', 'toggle']) ?? FALSE,
+    ];
+
+    $fieldset['button'] = [
+      '#type'                    => 'submit',
+      '#value'                   => $this->t('Preview'),
+      '#submit'                  => ['::previewSubmit'],
+      '#limit_validation_errors' => [
+        ['preview', 'selects'],
+        ['preview', 'settings'],
+        ['type'],
+        ['field_types'],
+        ['data'],
+        ['label'],
+      ],
+      '#ajax'                    => [
+        'callback' => '::previewAjaxCallback',
+        'wrapper'  => 'preview-output-wrapper',
+      ],
+      '#button_type'             => 'primary',
+    ];
+
+    $fieldset['output'] = [
+      '#type'       => 'container',
+      '#attributes' => ['id' => 'preview-output-wrapper'],
+    ];
+
+    $preview_output = $form_state->get('preview_output');
+    if ($preview_output !== NULL) {
+      $fieldset['output'][] = $preview_output;
+    }
+
+    return $fieldset;
+  }
+
+  /**
+   * Computes pre-selection defaults for preview selects.
+   *
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   *
+   * @return array
+   *   Associative array with entity_type, bundle, field, entity keys.
+   */
+  protected function getPreviewDefaults(FormStateInterface $form_state): array {
+    if ($form_state->hasValue(['preview', 'selects', 'entity_type'])) {
+      return [
+        'entity_type' => NULL,
+        'bundle'      => NULL,
+        'field'       => NULL,
+        'entity'      => NULL,
+      ];
+    }
+
+    $entity_types = $this->getPreviewEntityTypes();
+    $entity_type_id = isset($entity_types['node']) ? 'node' : (string) key($entity_types);
+
+    if (!$entity_type_id) {
+      return [
+        'entity_type' => NULL,
+        'bundle'      => NULL,
+        'field'       => NULL,
+        'entity'      => NULL,
+      ];
+    }
+
+    $bundles = $this->getPreviewBundles($entity_type_id);
+    $bundle = (string) key($bundles);
+
+    $field_types = (array) ($form_state->getValue('field_types') ?? $this->entity->get('field_types'));
+    $fields = $bundle ? $this->getPreviewFields($entity_type_id, $bundle, $field_types) : [];
+    $field_name = (string) key($fields);
+
+    $entities = $field_name ? $this->getPreviewEntities($entity_type_id, $bundle, $field_name) : [];
+    $entity_id = key($entities);
+
+    return [
+      'entity_type' => $entity_type_id,
+      'bundle'      => $bundle,
+      'field'       => $field_name,
+      'entity'      => $entity_id,
+    ];
+  }
+
+  /**
+   * AJAX callback for preview select changes.
+   *
+   * @param array $form
+   *   The form array.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   *
+   * @return array
+   *   The selects container render array.
+   */
+  public function previewSelectsAjax(array $form, FormStateInterface $form_state): array {
+    return $form['preview']['selects'];
+  }
+
+  /**
+   * AJAX callback for the preview button.
+   *
+   * @param array $form
+   *   The form array.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   *
+   * @return array
+   *   The preview output container render array.
+   */
+  public function previewAjaxCallback(array $form, FormStateInterface $form_state): array {
+    return $form['preview']['output'];
+  }
+
+  /**
+   * Submit handler for the preview button.
+   *
+   * @param array $form
+   *   The form array.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   */
+  public function previewSubmit(array $form, FormStateInterface $form_state): void {
+    $form_state->setRebuild(TRUE);
+
+    $selects = $form_state->getValue(['preview', 'selects']) ?? [];
+    $entity_type_id = $selects['entity_type'] ?? NULL;
+    $bundle = $selects['bundle'] ?? NULL;
+    $field_name = $selects['field'] ?? NULL;
+    $entity_id = $selects['entity'] ?? NULL;
+
+    if (empty($entity_type_id) || empty($bundle) || empty($field_name) || empty($entity_id)) {
+      $form_state->set('preview_output', [
+        '#theme'        => 'status_messages',
+        '#message_list' => [
+          'warning' => [$this->t('Please select an entity type, bundle, field, and entity to preview.')],
+        ],
+      ]);
+      return;
+    }
+
+    $entity = $this->entityTypeManager->getStorage($entity_type_id)->load($entity_id);
+    if (!$entity instanceof FieldableEntityInterface || !$entity->access('view')) {
+      $form_state->set('preview_output', [
+        '#theme'        => 'status_messages',
+        '#message_list' => [
+          'error' => [$this->t('Unable to load the selected entity.')],
+        ],
+      ]);
+      return;
+    }
+
+    if (!$entity->hasField($field_name)) {
+      $form_state->set('preview_output', [
+        '#theme'        => 'status_messages',
+        '#message_list' => [
+          'error' => [$this->t('The selected entity does not have the chosen field.')],
+        ],
+      ]);
+      return;
+    }
+
+    $items = $entity->get($field_name);
+    if ($items->isEmpty()) {
+      $form_state->set('preview_output', [
+        '#theme'        => 'status_messages',
+        '#message_list' => [
+          'warning' => [$this->t('The selected field has no data.')],
+        ],
+      ]);
+      return;
+    }
+
+    $data = $form_state->getValue('data');
+    if ($data === NULL) {
+      $data = $this->entity->get('data');
+    }
+
+    $temp_entity = Formatter::create([
+      'id'          => '__preview__',
+      'label'       => $form_state->getValue('label') ?? $this->entity->label(),
+      'type'        => $form_state->getValue('type') ?? $this->entity->get('type'),
+      'field_types' => (array) ($form_state->getValue('field_types') ?? $this->entity->get('field_types')),
+      'data'        => $data,
+    ]);
+
+    $formatter_type = $temp_entity->getFormatterType();
+    if (!$formatter_type) {
+      $form_state->set('preview_output', [
+        '#theme'        => 'status_messages',
+        '#message_list' => [
+          'error' => [$this->t('Unable to create formatter preview.')],
+        ],
+      ]);
+      return;
+    }
+
+    try {
+      $langcode = $entity->language()->getId();
+      $elements = $formatter_type->viewElements($items, $langcode);
+    }
+    catch (\Exception $e) {
+      $form_state->set('preview_output', [
+        '#theme'        => 'status_messages',
+        '#message_list' => [
+          'error' => [$this->t('Error rendering preview: @message', ['@message' => $e->getMessage()])],
+        ],
+      ]);
+      return;
+    }
+
+    $settings = $form_state->getValue(['preview', 'settings']) ?? [];
+    $output = $this->buildPreviewOutput($elements, $items, $entity_type_id, $bundle, $field_name, $entity, $settings, $formatter_type);
+
+    $form_state->set('preview_output', $output);
+  }
+
+  /**
+   * Builds the preview output render array.
+   *
+   * @param array $elements
+   *   The formatter render array.
+   * @param \Drupal\Core\Field\FieldItemListInterface $items
+   *   The field items.
+   * @param string $entity_type_id
+   *   The entity type ID.
+   * @param string $bundle
+   *   The bundle ID.
+   * @param string $field_name
+   *   The field name.
+   * @param \Drupal\Core\Entity\FieldableEntityInterface $entity
+   *   The entity.
+   * @param array $settings
+   *   The preview settings values.
+   * @param \Drupal\custom_formatters\FormatterTypeInterface $formatter_type
+   *   The formatter type plugin.
+   *
+   * @return array
+   *   The preview output render array.
+   */
+  protected function buildPreviewOutput(array $elements, FieldItemListInterface $items, string $entity_type_id, string $bundle, string $field_name, FieldableEntityInterface $entity, array $settings, FormatterTypeInterface $formatter_type): array {
+    $output = [];
+    $toggle = !empty($settings['toggle']);
+
+    if ($toggle && !empty($elements)) {
+      $field_definitions = $this->entityFieldManager->getFieldDefinitions($entity_type_id, $bundle);
+      $field_definition = $field_definitions[$field_name] ?? NULL;
+
+      if ($field_definition) {
+        $field_storage = $field_definition->getFieldStorageDefinition();
+        $field_build = [
+          '#theme'                 => 'field',
+          '#title'                 => $field_definition->getLabel(),
+          '#label_display'         => 'above',
+          '#view_mode'             => '_custom',
+          '#language'              => $items->getLangcode(),
+          '#field_name'            => $field_name,
+          '#field_type'            => $field_storage->getType(),
+          '#field_translatable'    => $field_storage->isTranslatable(),
+          '#entity_type'           => $entity_type_id,
+          '#bundle'                => $bundle,
+          '#object'                => $entity,
+          '#formatter'             => 'custom_formatters_preview',
+          '#is_multiple'           => $field_storage->isMultiple(),
+          '#third_party_settings'  => [],
+        ];
+
+        foreach ($elements as $key => $element) {
+          if (is_int($key)) {
+            $field_build[$key] = $element;
+          }
+        }
+
+        if (!isset($field_build[0])) {
+          $field_build[0] = $elements;
+        }
+
+        $rendered_html = (string) $this->renderer->renderRoot($field_build);
+      }
+      else {
+        $rendered_html = (string) $this->renderer->renderRoot($elements);
+      }
+    }
+    else {
+      $rendered_html = (string) $this->renderer->renderRoot($elements);
+    }
+
+    $output['preview'] = [
+      '#type'       => 'container',
+      '#attributes' => ['class' => ['formatter-preview-output']],
+      'content'     => [
+        '#markup' => $rendered_html,
+      ],
+    ];
+
+    if ($formatter_type->getPluginId() === 'php' && !empty($settings['debug_variables'])) {
+      $output['debug_variables'] = [
+        '#type'    => 'details',
+        '#title'   => $this->t('$items variable'),
+        'content'  => [
+          '#plain_text' => print_r($items->getValue(), TRUE),
+        ],
+      ];
+    }
+
+    if (!empty($settings['debug_html'])) {
+      $output['debug_html'] = [
+        '#type'    => 'details',
+        '#title'   => $this->t('Raw HTML'),
+        'content'  => [
+          '#plain_text' => $rendered_html,
+        ],
+      ];
+    }
+
+    return $output;
+  }
+
+  /**
+   * Returns entity type options for preview.
+   *
+   * @return array
+   *   Entity type labels keyed by entity type ID.
+   */
+  protected function getPreviewEntityTypes(): array {
+    $options = [];
+    foreach ($this->entityTypeManager->getDefinitions() as $entity_type) {
+      if ($entity_type->entityClassImplements('Drupal\Core\Entity\ContentEntityInterface') && $entity_type->hasKey('bundle')) {
+        $options[$entity_type->id()] = $entity_type->getLabel();
+      }
+    }
+    return $options;
+  }
+
+  /**
+   * Returns bundle options for an entity type.
+   *
+   * @param string $entity_type_id
+   *   The entity type ID.
+   *
+   * @return array
+   *   Bundle labels keyed by bundle ID.
+   */
+  protected function getPreviewBundles(string $entity_type_id): array {
+    $options = [];
+    $bundle_info = $this->entityTypeBundleInfo->getBundleInfo($entity_type_id);
+    foreach ($bundle_info as $bundle => $info) {
+      $options[$bundle] = $info['label'];
+    }
+    return $options;
+  }
+
+  /**
+   * Returns field options filtered by formatter field types.
+   *
+   * @param string $entity_type_id
+   *   The entity type ID.
+   * @param string $bundle
+   *   The bundle ID.
+   * @param array $field_types
+   *   The allowed field type IDs.
+   *
+   * @return array
+   *   Field labels keyed by field name.
+   */
+  protected function getPreviewFields(string $entity_type_id, string $bundle, array $field_types): array {
+    $options = [];
+    $field_definitions = $this->entityFieldManager->getFieldDefinitions($entity_type_id, $bundle);
+    foreach ($field_definitions as $field_name => $definition) {
+      if ($definition instanceof FieldConfigInterface && in_array($definition->getType(), $field_types, TRUE)) {
+        $options[$field_name] = $definition->getLabel();
+      }
+    }
+    return $options;
+  }
+
+  /**
+   * Returns entity options with data in a specific field.
+   *
+   * @param string $entity_type_id
+   *   The entity type ID.
+   * @param string $bundle
+   *   The bundle ID.
+   * @param string $field_name
+   *   The field name.
+   *
+   * @return array
+   *   Entity labels keyed by entity ID, limited to 50.
+   */
+  protected function getPreviewEntities(string $entity_type_id, string $bundle, string $field_name): array {
+    $options = [];
+    $entity_type = $this->entityTypeManager->getDefinition($entity_type_id);
+    $storage = $this->entityTypeManager->getStorage($entity_type_id);
+
+    $query = $storage->getQuery()
+      ->accessCheck(TRUE)
+      ->range(0, 50);
+
+    if ($bundle_key = $entity_type->getKey('bundle')) {
+      $query->condition($bundle_key, $bundle);
+    }
+
+    // Filter to entities with non-empty field data.
+    $query->exists($field_name);
+
+    $ids = $query->execute();
+    if (empty($ids)) {
+      return $options;
+    }
+
+    $entities = $storage->loadMultiple($ids);
+    foreach ($entities as $id => $entity) {
+      if ($entity->access('view')) {
+        $options[$id] = $entity->label() ?: (string) $id;
+      }
+    }
+
+    return $options;
   }
 
   /**
@@ -245,8 +823,8 @@ class FormatterForm extends EntityForm {
   protected function actions(array $form, FormStateInterface $form_state) {
     $actions = parent::actions($form, $form_state);
     $actions['save_and_edit'] = [
-      '#type' => 'submit',
-      '#value' => $this->t('Save & Edit'),
+      '#type'   => 'submit',
+      '#value'  => $this->t('Save & Edit'),
       '#submit' => ['::submitForm', '::saveAndEdit'],
       '#weight' => 10,
     ];

--- a/src/Form/FormatterForm.php
+++ b/src/Form/FormatterForm.php
@@ -82,7 +82,7 @@ class FormatterForm extends EntityForm {
   /**
    * The Devel dumper service, or NULL if Devel is not installed.
    *
-   * @var object|null
+   * @var \Drupal\devel\DevelDumperManagerInterface|null
    */
   protected $develDumper = NULL;
 
@@ -101,7 +101,7 @@ class FormatterForm extends EntityForm {
    *   The entity type bundle info service.
    * @param \Drupal\Core\Render\RendererInterface $renderer
    *   The renderer service.
-   * @param object|null $devel_dumper
+   * @param \Drupal\devel\DevelDumperManagerInterface|null $devel_dumper
    *   The Devel dumper service, or NULL if Devel is not installed.
    */
   public function __construct(FormatterExtrasManager $formatter_extras_manager, FormatterPluginManager $field_formatter_manager, FieldTypePluginManagerInterface $field_type_manager, EntityFieldManagerInterface $entity_field_manager, EntityTypeBundleInfoInterface $entity_type_bundle_info, RendererInterface $renderer, $devel_dumper = NULL) {

--- a/src/Form/FormatterForm.php
+++ b/src/Form/FormatterForm.php
@@ -80,6 +80,13 @@ class FormatterForm extends EntityForm {
   protected $renderer;
 
   /**
+   * The Devel dumper service, or NULL if Devel is not installed.
+   *
+   * @var object|null
+   */
+  protected $develDumper = NULL;
+
+  /**
    * Constructs a FormatterForm object.
    *
    * @param \Drupal\custom_formatters\FormatterExtrasManager $formatter_extras_manager
@@ -94,27 +101,35 @@ class FormatterForm extends EntityForm {
    *   The entity type bundle info service.
    * @param \Drupal\Core\Render\RendererInterface $renderer
    *   The renderer service.
+   * @param object|null $devel_dumper
+   *   The Devel dumper service, or NULL if Devel is not installed.
    */
-  public function __construct(FormatterExtrasManager $formatter_extras_manager, FormatterPluginManager $field_formatter_manager, FieldTypePluginManagerInterface $field_type_manager, EntityFieldManagerInterface $entity_field_manager, EntityTypeBundleInfoInterface $entity_type_bundle_info, RendererInterface $renderer) {
+  public function __construct(FormatterExtrasManager $formatter_extras_manager, FormatterPluginManager $field_formatter_manager, FieldTypePluginManagerInterface $field_type_manager, EntityFieldManagerInterface $entity_field_manager, EntityTypeBundleInfoInterface $entity_type_bundle_info, RendererInterface $renderer, $devel_dumper = NULL) {
     $this->formatterExtrasManager = $formatter_extras_manager;
     $this->fieldTypeManager = $field_type_manager;
     $this->fieldFormatterManager = $field_formatter_manager;
     $this->entityFieldManager = $entity_field_manager;
     $this->entityTypeBundleInfo = $entity_type_bundle_info;
     $this->renderer = $renderer;
+    $this->develDumper = $devel_dumper;
   }
 
   /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
+    // The Devel dumper service is optional. When the Devel module is not
+    // installed, the service won't exist and NULL is returned instead.
+    // This avoids hard-coding a dependency on an optional module.
+    $devel_dumper = $container->get('devel.dumper', ContainerInterface::NULL_ON_INVALID_REFERENCE);
     return new static(
       $container->get('plugin.manager.custom_formatters.formatter_extras'),
       $container->get('plugin.manager.field.formatter'),
       $container->get('plugin.manager.field.field_type'),
       $container->get('entity_field.manager'),
       $container->get('entity_type.bundle.info'),
-      $container->get('renderer')
+      $container->get('renderer'),
+      $devel_dumper
     );
   }
 
@@ -209,11 +224,9 @@ class FormatterForm extends EntityForm {
     $form['plugin']['#prefix'] = "<div id='plugin-wrapper'>";
     $form['plugin']['#suffix'] = "</div>";
 
-    // Extras vertical tabs group — always rendered so preview tab can join.
-    $form['vertical_tabs'] = [
-      '#type'    => 'vertical_tabs',
-      '#title'   => $this->t('Extras'),
-      '#parents' => ['extras'],
+    // Additional settings vertical tabs group.
+    $form['additional_settings'] = [
+      '#type' => 'vertical_tabs',
     ];
 
     // Preview section.
@@ -244,7 +257,7 @@ class FormatterForm extends EntityForm {
     $fieldset = [
       '#type'   => 'details',
       '#title'  => $this->t('Preview'),
-      '#group'  => 'extras',
+      '#group'  => 'additional_settings',
       '#weight' => -10,
       '#tree'   => TRUE,
     ];
@@ -282,86 +295,87 @@ class FormatterForm extends EntityForm {
       $entity_id = key($entity_options) ?: NULL;
     }
 
+    $preview_disabled = empty($entity_options);
+
+    // Build the selects container with a flexbox-friendly class. The CSS
+    // targets .preview-selects to arrange selects and the preview button
+    // horizontally, matching the Claro admin theme's exposed filter layout.
     $fieldset['selects'] = [
       '#type'       => 'container',
-      '#attributes' => ['class' => ['preview-selects-row']],
+      '#attributes' => ['class' => ['preview-selects']],
       '#prefix'     => '<div id="preview-selects-wrapper">',
       '#suffix'     => '</div>',
     ];
 
+    // Entity type, bundle, field, and entity selects form a cascading
+    // hierarchy. Each select triggers an AJAX rebuild of the entire selects
+    // container, ensuring downstream options are recalculated on every change.
     $fieldset['selects']['entity_type'] = [
-      '#type'          => 'select',
-      '#title'         => $this->t('Entity type'),
-      '#options'       => $entity_type_options,
-      '#default_value' => $entity_type_id,
-      '#empty_option'  => $this->t('- Select -'),
-      '#ajax'          => [
+      '#type'               => 'select',
+      '#title'              => $this->t('Entity type'),
+      '#options'            => $entity_type_options,
+      '#default_value'      => $entity_type_id,
+      '#empty_option'       => $this->t('- Select -'),
+      '#ajax'               => [
         'callback' => '::previewSelectsAjax',
         'wrapper'  => 'preview-selects-wrapper',
       ],
     ];
 
     $fieldset['selects']['bundle'] = [
-      '#type'          => 'select',
-      '#title'         => $this->t('Bundle'),
-      '#options'       => $bundle_options,
-      '#default_value' => $bundle,
-      '#empty_option'  => $this->t('- Select -'),
-      '#validated'     => TRUE,
-      '#ajax'          => [
+      '#type'               => 'select',
+      '#title'              => $this->t('Bundle'),
+      '#options'            => $bundle_options,
+      '#default_value'      => $bundle,
+      '#empty_option'       => $this->t('- Select -'),
+      '#validated'          => TRUE,
+      '#disabled'           => empty($bundle_options),
+      '#ajax'               => [
         'callback' => '::previewSelectsAjax',
         'wrapper'  => 'preview-selects-wrapper',
       ],
     ];
 
     $fieldset['selects']['field'] = [
-      '#type'          => 'select',
-      '#title'         => $this->t('Field'),
-      '#options'       => $field_options,
-      '#default_value' => $field_name,
-      '#empty_option'  => $this->t('- Select -'),
-      '#validated'     => TRUE,
-      '#ajax'          => [
+      '#type'               => 'select',
+      '#title'              => $this->t('Field'),
+      '#options'            => $field_options,
+      '#default_value'      => $field_name,
+      '#empty_option'       => empty($field_options) && !empty($bundle_options)
+        ? $this->t('No fields')
+        : $this->t('- Select -'),
+      '#validated'          => TRUE,
+      '#disabled'           => empty($field_options),
+      '#ajax'               => [
         'callback' => '::previewSelectsAjax',
         'wrapper'  => 'preview-selects-wrapper',
       ],
     ];
 
     $fieldset['selects']['entity'] = [
-      '#type'          => 'select',
-      '#title'         => $this->t('Entity'),
-      '#options'       => $entity_options,
-      '#default_value' => $entity_id,
-      '#empty_option'  => $this->t('- Select -'),
-      '#validated'     => TRUE,
+      '#type'               => 'select',
+      '#title'              => $this->t('Entity'),
+      '#options'            => $entity_options,
+      '#default_value'      => $entity_id,
+      '#empty_option'       => $preview_disabled && !empty($field_options)
+        ? $this->t('No data')
+        : $this->t('- Select -'),
+      '#validated'          => TRUE,
+      '#disabled'           => $preview_disabled,
     ];
 
-    $formatter_type = $this->entity->getFormatterType();
-
-    $fieldset['settings'] = [
-      '#type'       => 'container',
-      '#attributes' => ['class' => ['preview-settings-row']],
-    ];
-
-    if ($formatter_type) {
-      foreach ($formatter_type->previewSettingsForm() as $key => $element) {
-        $fieldset['settings'][$key] = $element;
-      }
-    }
-
-    $fieldset['settings']['toggle'] = [
-      '#type'          => 'checkbox',
-      '#title'         => $this->t('Show full field theming'),
-      '#default_value' => $form_state->getValue(['preview', 'settings', 'toggle']) ?? FALSE,
-    ];
-
-    $fieldset['button'] = [
+    // Place the Preview button inside the selects container so that CSS
+    // flexbox rules include it in the horizontal layout alongside the
+    // selects. The #type is 'submit' (not 'button') to ensure
+    // BrowserTestBase can target it reliably in functional tests.
+    $fieldset['selects']['button'] = [
       '#type'                    => 'submit',
       '#value'                   => $this->t('Preview'),
       '#submit'                  => ['::previewSubmit'],
       '#limit_validation_errors' => [
         ['preview', 'selects'],
-        ['preview', 'settings'],
+        ['preview', 'debug'],
+        ['preview', 'toggle'],
         ['type'],
         ['field_types'],
         ['data'],
@@ -372,6 +386,35 @@ class FormatterForm extends EntityForm {
         'wrapper'  => 'preview-output-wrapper',
       ],
       '#button_type'             => 'primary',
+      '#disabled'                => $preview_disabled,
+      '#prefix'                  => '<div class="preview-actions">',
+      '#suffix'                  => '</div>',
+    ];
+
+    $formatter_type = $this->entity->getFormatterType();
+
+    // Only include the debug settings when Devel is installed, following
+    // the core pattern of conditional form element inclusion (e.g.,
+    // NodeTypeForm hides language settings when Language module is disabled).
+    if ($this->moduleHandler->moduleExists('devel')) {
+      $debug_form = $formatter_type ? $formatter_type->previewSettingsForm() : [];
+      if (!empty($debug_form)) {
+        $fieldset['debug'] = [
+          '#type'  => 'details',
+          '#title' => $this->t('Debugging'),
+          '#open'  => FALSE,
+        ];
+
+        foreach ($debug_form as $key => $element) {
+          $fieldset['debug'][$key] = $element;
+        }
+      }
+    }
+
+    $fieldset['toggle'] = [
+      '#type'          => 'checkbox',
+      '#title'         => $this->t('Show full field theming'),
+      '#default_value' => $form_state->getValue(['preview', 'toggle']) ?? FALSE,
     ];
 
     $fieldset['output'] = [
@@ -563,8 +606,9 @@ class FormatterForm extends EntityForm {
       return;
     }
 
-    $settings = $form_state->getValue(['preview', 'settings']) ?? [];
-    $output = $this->buildPreviewOutput($elements, $items, $entity_type_id, $bundle, $field_name, $entity, $settings, $formatter_type);
+    $settings = $form_state->getValue(['preview', 'debug']) ?? [];
+    $toggle = !empty($form_state->getValue(['preview', 'toggle']));
+    $output = $this->buildPreviewOutput($elements, $items, $entity_type_id, $bundle, $field_name, $entity, $settings, $toggle, $formatter_type);
 
     $form_state->set('preview_output', $output);
   }
@@ -586,15 +630,16 @@ class FormatterForm extends EntityForm {
    *   The entity.
    * @param array $settings
    *   The preview settings values.
+   * @param bool $toggle
+   *   Whether to show full field theming.
    * @param \Drupal\custom_formatters\FormatterTypeInterface $formatter_type
    *   The formatter type plugin.
    *
    * @return array
    *   The preview output render array.
    */
-  protected function buildPreviewOutput(array $elements, FieldItemListInterface $items, string $entity_type_id, string $bundle, string $field_name, FieldableEntityInterface $entity, array $settings, FormatterTypeInterface $formatter_type): array {
+  protected function buildPreviewOutput(array $elements, FieldItemListInterface $items, string $entity_type_id, string $bundle, string $field_name, FieldableEntityInterface $entity, array $settings, bool $toggle, FormatterTypeInterface $formatter_type): array {
     $output = [];
-    $toggle = !empty($settings['toggle']);
 
     if ($toggle && !empty($elements)) {
       $field_definitions = $this->entityFieldManager->getFieldDefinitions($entity_type_id, $bundle);
@@ -647,23 +692,37 @@ class FormatterForm extends EntityForm {
       ],
     ];
 
-    if ($formatter_type->getPluginId() === 'php' && !empty($settings['debug_variables'])) {
+    // Devel must be installed for debug checkboxes to appear. When enabled,
+    // its dumper service produces styled output matching dpm()/kpr(). For
+    // engines with multiple template variables (Twig, HTML+Token), the
+    // output dumps all available variables bundled together.
+    if (!empty($settings['debug_variables'])) {
+      $debug_data = $items->getValue();
+
+      if ($formatter_type->getPluginId() === 'twig') {
+        $debug_data = [
+          'items' => $items,
+          'langcode' => $items->getLangcode(),
+          'entity' => $entity,
+        ];
+      }
+
+      if ($formatter_type->getPluginId() === 'html_token') {
+        $debug_data = $entity;
+      }
+
       $output['debug_variables'] = [
-        '#type'    => 'details',
-        '#title'   => $this->t('$items variable'),
-        'content'  => [
-          '#plain_text' => print_r($items->getValue(), TRUE),
-        ],
+        '#type' => 'container',
+        '#attributes' => ['class' => ['formatter-preview-debug']],
+        'dump' => $this->develDumper->exportAsRenderable($debug_data),
       ];
     }
 
     if (!empty($settings['debug_html'])) {
       $output['debug_html'] = [
-        '#type'    => 'details',
-        '#title'   => $this->t('Raw HTML'),
-        'content'  => [
-          '#plain_text' => $rendered_html,
-        ],
+        '#type' => 'container',
+        '#attributes' => ['class' => ['formatter-preview-debug']],
+        'dump' => $this->develDumper->exportAsRenderable($rendered_html),
       ];
     }
 
@@ -787,14 +846,12 @@ class FormatterForm extends EntityForm {
         $extras_form = $this->formatterExtrasManager->invoke($definition['id'], 'settingsForm', $this->entity);
 
         if (is_array($extras_form) && !empty($extras_form)) {
-          // Extras form.
           $form[$definition['id']] = $extras_form;
 
-          // Extras form details element.
           $form[$definition['id']]['#type'] = 'details';
           $form[$definition['id']]['#title'] = $definition['label'];
           $form[$definition['id']]['#description'] = $definition['description'];
-          $form[$definition['id']]['#group'] = 'extras';
+          $form[$definition['id']]['#group'] = 'additional_settings';
         }
       }
     }

--- a/src/Form/FormatterForm.php
+++ b/src/Form/FormatterForm.php
@@ -397,7 +397,7 @@ class FormatterForm extends EntityForm {
     // the core pattern of conditional form element inclusion (e.g.,
     // NodeTypeForm hides language settings when Language module is disabled).
     if ($this->moduleHandler->moduleExists('devel')) {
-      $debug_form = $formatter_type ? $formatter_type->previewSettingsForm() : [];
+      $debug_form = $formatter_type && method_exists($formatter_type, 'previewSettingsForm') ? $formatter_type->previewSettingsForm() : [];
       if (!empty($debug_form)) {
         $fieldset['debug'] = [
           '#type'  => 'details',

--- a/src/Form/FormatterForm.php
+++ b/src/Form/FormatterForm.php
@@ -693,22 +693,14 @@ class FormatterForm extends EntityForm {
     ];
 
     // Devel must be installed for debug checkboxes to appear. When enabled,
-    // its dumper service produces styled output matching dpm()/kpr(). For
-    // engines with multiple template variables (Twig, HTML+Token), the
-    // output dumps all available variables bundled together.
+    // its dumper service produces styled output matching dpm()/kpr(). Each
+    // engine provides its own debug data via previewDebugData() on
+    // FormatterTypeBase, defaulting to $items->getValue().
     if (!empty($settings['debug_variables'])) {
       $debug_data = $items->getValue();
 
-      if ($formatter_type->getPluginId() === 'twig') {
-        $debug_data = [
-          'items' => $items,
-          'langcode' => $items->getLangcode(),
-          'entity' => $entity,
-        ];
-      }
-
-      if ($formatter_type->getPluginId() === 'html_token') {
-        $debug_data = $entity;
+      if (method_exists($formatter_type, 'previewDebugData')) {
+        $debug_data = $formatter_type->previewDebugData($items, $entity);
       }
 
       $output['debug_variables'] = [

--- a/src/FormatterTypeBase.php
+++ b/src/FormatterTypeBase.php
@@ -9,7 +9,9 @@ declare(strict_types=1);
 
 namespace Drupal\custom_formatters;
 
+use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Plugin\PluginBase;
@@ -156,6 +158,13 @@ abstract class FormatterTypeBase extends PluginBase implements FormatterTypeInte
    */
   public function previewSettingsForm(): array {
     return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function previewDebugData(FieldItemListInterface $items, FieldableEntityInterface $entity): mixed {
+    return $items->getValue();
   }
 
 }

--- a/src/FormatterTypeBase.php
+++ b/src/FormatterTypeBase.php
@@ -154,14 +154,34 @@ abstract class FormatterTypeBase extends PluginBase implements FormatterTypeInte
   }
 
   /**
-   * {@inheritdoc}
+   * Returns engine-specific preview settings form elements.
+   *
+   * Allows each engine type to contribute debug options to the preview
+   * section, such as variable dumps or raw HTML output. Third-party
+   * plugins that do not override this method will not display debug
+   * settings in the preview section.
+   *
+   * @return array
+   *   A form array of preview settings elements.
    */
   public function previewSettingsForm(): array {
     return [];
   }
 
   /**
-   * {@inheritdoc}
+   * Returns engine-specific preview debug data.
+   *
+   * Each engine can override this to provide debug output tailored to its
+   * template context. Called via method_exists() guard in FormatterForm
+   * to preserve BC with third-party plugins that don't implement it.
+   *
+   * @param \Drupal\Core\Field\FieldItemListInterface $items
+   *   The field items being rendered.
+   * @param \Drupal\Core\Entity\FieldableEntityInterface $entity
+   *   The entity being previewed.
+   *
+   * @return mixed
+   *   Data suitable for Devel's dumper output.
    */
   public function previewDebugData(FieldItemListInterface $items, FieldableEntityInterface $entity): mixed {
     return $items->getValue();

--- a/src/FormatterTypeBase.php
+++ b/src/FormatterTypeBase.php
@@ -151,4 +151,11 @@ abstract class FormatterTypeBase extends PluginBase implements FormatterTypeInte
   public function submitForm(array $form, FormStateInterface $form_state): void {
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function previewSettingsForm(): array {
+    return [];
+  }
+
 }

--- a/src/FormatterTypeInterface.php
+++ b/src/FormatterTypeInterface.php
@@ -73,15 +73,4 @@ interface FormatterTypeInterface extends PluginInspectionInterface {
    */
   public function preSave(): void;
 
-  /**
-   * Returns engine-specific preview settings form elements.
-   *
-   * Allows each engine type to contribute debug options to the preview
-   * section, such as variable dumps or raw HTML output.
-   *
-   * @return array
-   *   A form array of preview settings elements.
-   */
-  public function previewSettingsForm(): array;
-
 }

--- a/src/FormatterTypeInterface.php
+++ b/src/FormatterTypeInterface.php
@@ -73,4 +73,15 @@ interface FormatterTypeInterface extends PluginInspectionInterface {
    */
   public function preSave(): void;
 
+  /**
+   * Returns engine-specific preview settings form elements.
+   *
+   * Allows each engine type to contribute debug options to the preview
+   * section, such as variable dumps or raw HTML output.
+   *
+   * @return array
+   *   A form array of preview settings elements.
+   */
+  public function previewSettingsForm(): array;
+
 }

--- a/src/Plugin/CustomFormatters/FormatterType/FormatterPreset.php
+++ b/src/Plugin/CustomFormatters/FormatterType/FormatterPreset.php
@@ -39,6 +39,13 @@ class FormatterPreset extends FormatterTypeBase {
   protected $formatterManager = NULL;
 
   /**
+   * The module handler service.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected ModuleHandlerInterface $moduleHandler;
+
+  /**
    * {@inheritdoc}
    */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, ModuleHandlerInterface $module_handler, FormatterPluginManager $formatter_manager) {
@@ -51,6 +58,23 @@ class FormatterPreset extends FormatterTypeBase {
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
     return new static($configuration, $plugin_id, $plugin_definition, $container->get('module_handler'), $container->get('plugin.manager.field.formatter'));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function previewSettingsForm(): array {
+    $devel_exists = $this->moduleHandler->moduleExists('devel');
+
+    return [
+      'debug_html' => [
+        '#type'          => 'checkbox',
+        '#title'         => $this->t('Output raw HTML'),
+        '#default_value' => FALSE,
+        '#disabled'      => !$devel_exists,
+        '#description'   => !$devel_exists ? $this->t('Requires Devel module.') : '',
+      ],
+    ];
   }
 
   /**

--- a/src/Plugin/CustomFormatters/FormatterType/HTMLToken.php
+++ b/src/Plugin/CustomFormatters/FormatterType/HTMLToken.php
@@ -117,6 +117,13 @@ class HTMLToken extends FormatterTypeBase {
     $devel_exists = $this->moduleHandler->moduleExists('devel');
 
     return [
+      'debug_variables' => [
+        '#type'          => 'checkbox',
+        '#title'         => $this->t('Output token context (entity)'),
+        '#default_value' => FALSE,
+        '#disabled'      => !$devel_exists,
+        '#description'   => !$devel_exists ? $this->t('Requires Devel module.') : '',
+      ],
       'debug_html' => [
         '#type'          => 'checkbox',
         '#title'         => $this->t('Output raw HTML'),

--- a/src/Plugin/CustomFormatters/FormatterType/HTMLToken.php
+++ b/src/Plugin/CustomFormatters/FormatterType/HTMLToken.php
@@ -11,6 +11,7 @@ namespace Drupal\custom_formatters\Plugin\CustomFormatters\FormatterType;
 
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem;
@@ -132,6 +133,13 @@ class HTMLToken extends FormatterTypeBase {
         '#description'   => !$devel_exists ? $this->t('Requires Devel module.') : '',
       ],
     ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function previewDebugData(FieldItemListInterface $items, FieldableEntityInterface $entity): mixed {
+    return $entity;
   }
 
   /**

--- a/src/Plugin/CustomFormatters/FormatterType/HTMLToken.php
+++ b/src/Plugin/CustomFormatters/FormatterType/HTMLToken.php
@@ -113,6 +113,23 @@ class HTMLToken extends FormatterTypeBase {
   /**
    * {@inheritdoc}
    */
+  public function previewSettingsForm(): array {
+    $devel_exists = $this->moduleHandler->moduleExists('devel');
+
+    return [
+      'debug_html' => [
+        '#type'          => 'checkbox',
+        '#title'         => $this->t('Output raw HTML'),
+        '#default_value' => FALSE,
+        '#disabled'      => !$devel_exists,
+        '#description'   => !$devel_exists ? $this->t('Requires Devel module.') : '',
+      ],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function viewElements(FieldItemListInterface $items, $langcode) {
     $element = [];
 

--- a/src/Plugin/CustomFormatters/FormatterType/Php.php
+++ b/src/Plugin/CustomFormatters/FormatterType/Php.php
@@ -9,11 +9,9 @@ declare(strict_types=1);
 
 namespace Drupal\custom_formatters\Plugin\CustomFormatters\FormatterType;
 
-use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\custom_formatters\FormatterTypeBase;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Plugin implementation of the PHP Formatter type.
@@ -31,26 +29,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * )
  */
 class Php extends FormatterTypeBase {
-
-  /**
-   * The module handler service.
-   */
-  protected ModuleHandlerInterface $moduleHandler;
-
-  /**
-   * {@inheritdoc}
-   */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, ModuleHandlerInterface $module_handler) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition);
-    $this->moduleHandler = $module_handler;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static($configuration, $plugin_id, $plugin_definition, $container->get('module_handler'));
-  }
 
   /**
    * {@inheritdoc}

--- a/src/Plugin/CustomFormatters/FormatterType/Php.php
+++ b/src/Plugin/CustomFormatters/FormatterType/Php.php
@@ -9,9 +9,11 @@ declare(strict_types=1);
 
 namespace Drupal\custom_formatters\Plugin\CustomFormatters\FormatterType;
 
+use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\custom_formatters\FormatterTypeBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Plugin implementation of the PHP Formatter type.
@@ -29,6 +31,26 @@ use Drupal\custom_formatters\FormatterTypeBase;
  * )
  */
 class Php extends FormatterTypeBase {
+
+  /**
+   * The module handler service.
+   */
+  protected ModuleHandlerInterface $moduleHandler;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, ModuleHandlerInterface $module_handler) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->moduleHandler = $module_handler;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static($configuration, $plugin_id, $plugin_definition, $container->get('module_handler'));
+  }
 
   /**
    * {@inheritdoc}
@@ -54,20 +76,37 @@ class Php extends FormatterTypeBase {
   /**
    * {@inheritdoc}
    */
+  public function previewSettingsForm(): array {
+    $devel_exists = $this->moduleHandler->moduleExists('devel');
+    $form = [];
+
+    $form['debug_variables'] = [
+      '#type'          => 'checkbox',
+      '#title'         => $this->t('Output <strong>$items</strong> variable'),
+      '#default_value' => FALSE,
+      '#disabled'      => !$devel_exists,
+      '#description'   => !$devel_exists ? $this->t('Requires Devel module.') : '',
+    ];
+
+    $form['debug_html'] = [
+      '#type'          => 'checkbox',
+      '#title'         => $this->t('Output raw HTML'),
+      '#default_value' => FALSE,
+      '#disabled'      => !$devel_exists,
+      '#description'   => !$devel_exists ? $this->t('Requires Devel module.') : '',
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function viewElements(FieldItemListInterface $items, $langcode) {
     ob_start();
     $output = eval($this->entity->get('data')); // phpcs:ignore Drupal.Functions.DiscouragedFunctions.Discouraged
     $output = !empty($output) ? $output : ob_get_contents();
     ob_end_clean();
-
-    // Preview debugging; Show the available variables data.
-    // @todo Re-add when preview functionality re-added.
-    // phpcs:disable Drupal.Files.LineLength.TooLong
-    // phpcs:disable Drupal.Commenting.InlineComment.NotCapital
-    // if (\Drupal::moduleHandler()->moduleExists('devel') && isset($formatter->preview) && $formatter->preview['options']['dpm']['vars']) {
-    // dpm($variables);
-    // }
-    // phpcs:enable
 
     return empty($output) ? [] : (is_array($output) ? $output : ['#markup' => $output]);
   }

--- a/src/Plugin/CustomFormatters/FormatterType/Twig.php
+++ b/src/Plugin/CustomFormatters/FormatterType/Twig.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Drupal\custom_formatters\Plugin\CustomFormatters\FormatterType;
 
+use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
@@ -97,6 +98,17 @@ class Twig extends FormatterTypeBase {
         '#disabled'      => !$devel_exists,
         '#description'   => !$devel_exists ? $this->t('Requires Devel module.') : '',
       ],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function previewDebugData(FieldItemListInterface $items, FieldableEntityInterface $entity): mixed {
+    return [
+      'items' => $items,
+      'langcode' => $items->getLangcode(),
+      'entity' => $entity,
     ];
   }
 

--- a/src/Plugin/CustomFormatters/FormatterType/Twig.php
+++ b/src/Plugin/CustomFormatters/FormatterType/Twig.php
@@ -79,6 +79,23 @@ class Twig extends FormatterTypeBase {
   /**
    * {@inheritdoc}
    */
+  public function previewSettingsForm(): array {
+    $devel_exists = $this->moduleHandler->moduleExists('devel');
+
+    return [
+      'debug_html' => [
+        '#type'          => 'checkbox',
+        '#title'         => $this->t('Output raw HTML'),
+        '#default_value' => FALSE,
+        '#disabled'      => !$devel_exists,
+        '#description'   => !$devel_exists ? $this->t('Requires Devel module.') : '',
+      ],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function viewElements(FieldItemListInterface $items, $langcode): array {
     $output = '';
 

--- a/src/Plugin/CustomFormatters/FormatterType/Twig.php
+++ b/src/Plugin/CustomFormatters/FormatterType/Twig.php
@@ -83,6 +83,13 @@ class Twig extends FormatterTypeBase {
     $devel_exists = $this->moduleHandler->moduleExists('devel');
 
     return [
+      'debug_variables' => [
+        '#type'          => 'checkbox',
+        '#title'         => $this->t('Output template variables (items, langcode, entity)'),
+        '#default_value' => FALSE,
+        '#disabled'      => !$devel_exists,
+        '#description'   => !$devel_exists ? $this->t('Requires Devel module.') : '',
+      ],
       'debug_html' => [
         '#type'          => 'checkbox',
         '#title'         => $this->t('Output raw HTML'),

--- a/styles/custom_formatters.css
+++ b/styles/custom_formatters.css
@@ -4,3 +4,34 @@
   white-space: pre-line;
   word-wrap: break-word;
 }
+
+.preview-selects-row {
+  display: flex;
+  gap: 1em;
+}
+
+.preview-selects-row .form-item {
+  flex: 1;
+  min-width: 0;
+}
+
+.preview-settings-row {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1em;
+  margin-top: 0.5em;
+}
+
+.formatter-preview-output {
+  background: #fff;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  margin-top: 1em;
+  padding: 1em;
+}
+
+.formatter-preview-output img {
+  height: auto;
+  max-width: 100%;
+}

--- a/styles/custom_formatters.css
+++ b/styles/custom_formatters.css
@@ -25,14 +25,14 @@
 }
 
 .preview-selects > .form-item {
-  margin-block: var(--space-s) 0;
-  margin-inline: 0 var(--space-xs);
+  margin-block: var(--space-s, 0.75rem) 0;
+  margin-inline: 0 var(--space-xs, 0.5rem);
   max-width: 100%;
 }
 
 .preview-selects > .preview-actions {
   flex: 0 0 auto;
-  margin-top: var(--space-s);
+  margin-top: var(--space-s, 0.75rem);
   min-width: 0;
 }
 
@@ -65,5 +65,5 @@
  * class to provide vertical spacing from the preview output above.
  */
 .formatter-preview-debug {
-  margin-top: var(--space-l);
+  margin-top: var(--space-l, 1.5rem);
 }

--- a/styles/custom_formatters.css
+++ b/styles/custom_formatters.css
@@ -5,24 +5,46 @@
   word-wrap: break-word;
 }
 
-.preview-selects-row {
+/**
+ * Preview selects horizontal layout.
+ *
+ * Arranges the entity type, bundle, field, entity selects, and the Preview
+ * button in a single flex row, visually matching the Claro admin theme's
+ * exposed filter layout used on /admin/content. Uses a custom class
+ * (.preview-selects) rather than piggybacking on Claro's
+ * .views-exposed-form CSS, which targets the <form> element and only fires
+ * for Views exposed forms.
+ *
+ * @see \Drupal\custom_formatters\Form\FormatterForm::buildPreviewFieldset()
+ */
+.preview-selects {
+  align-items: flex-end;
   display: flex;
-  gap: 1em;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
 }
 
-.preview-selects-row .form-item {
-  flex: 1;
+.preview-selects > .form-item {
+  margin-block: var(--space-s) 0;
+  margin-inline: 0 var(--space-xs);
+  max-width: 100%;
+}
+
+.preview-selects > .preview-actions {
+  flex: 0 0 auto;
+  margin-top: var(--space-s);
   min-width: 0;
 }
 
-.preview-settings-row {
-  align-items: center;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1em;
-  margin-top: 0.5em;
+.preview-selects > .preview-actions input {
+  margin: 0;
 }
 
+/**
+ * Preview output container.
+ *
+ * @see template_preprocess_formatter_preview()
+ */
 .formatter-preview-output {
   background: #fff;
   border: 1px solid #ccc;
@@ -34,4 +56,14 @@
 .formatter-preview-output img {
   height: auto;
   max-width: 100%;
+}
+
+/**
+ * Debug output spacing.
+ *
+ * Debug sections (variables, HTML) are wrapped in a container with this
+ * class to provide vertical spacing from the preview output above.
+ */
+.formatter-preview-debug {
+  margin-top: var(--space-l);
 }

--- a/templates/formatter-preview.html.twig
+++ b/templates/formatter-preview.html.twig
@@ -1,0 +1,16 @@
+{#
+/**
+ * @file
+ * Default theme implementation for the formatter preview output.
+ *
+ * Available variables:
+ * - content: The rendered formatter preview content.
+ *
+ * @ingroup themeable
+ */
+#}
+{% if content %}
+  <div class="formatter-preview-output">
+    {{ content }}
+  </div>
+{% endif %}

--- a/tests/src/Kernel/FormatterPreviewFormTest.php
+++ b/tests/src/Kernel/FormatterPreviewFormTest.php
@@ -1,0 +1,418 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @file
+ * Kernel tests for the preview functionality in FormatterForm.
+ */
+
+namespace Drupal\Tests\custom_formatters\Kernel;
+
+use Drupal\Core\Entity\FieldableEntityInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\custom_formatters\Form\FormatterForm;
+use Drupal\custom_formatters\FormatterInterface;
+use Drupal\custom_formatters\FormatterTypeInterface;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\node\NodeTypeInterface;
+
+/**
+ * Tests the preview section on the formatter entity form.
+ *
+ * Verifies the preview selects layout (flexbox container, button placement),
+ * conditional inclusion of debug settings based on Devel module availability,
+ * and the Devel dumper integration for debug output.
+ *
+ * These tests run as kernel tests to ensure code coverage is collected,
+ * since functional tests execute form submissions via HTTP to a separate
+ * PHP process where pcov cannot track coverage.
+ *
+ * @see \Drupal\custom_formatters\Form\FormatterForm::buildPreviewFieldset()
+ * @see \Drupal\custom_formatters\Form\FormatterForm::buildPreviewOutput()
+ *
+ * @group custom_formatters
+ */
+class FormatterPreviewFormTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'custom_formatters',
+    'field',
+    'node',
+    'system',
+    'text',
+    'user',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installConfig(['custom_formatters', 'node']);
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('user');
+
+    // Create an article content type so the preview selects have entity
+    // types, bundles, and fields to work with.
+    $node_type = $this->container->get('entity_type.manager')
+      ->getStorage('node_type')
+      ->create([
+        'type' => 'article',
+        'name' => 'Article',
+      ]);
+    assert($node_type instanceof NodeTypeInterface);
+
+    // In Drupal 11, node_add_body_field() expects the body field storage to
+    // already exist (provided by the Standard profile). Create it before
+    // saving the node type so node_node_type_insert() doesn't fail.
+    if (!FieldStorageConfig::loadByName('node', 'body')) {
+      FieldStorageConfig::create([
+        'field_name' => 'body',
+        'entity_type' => 'node',
+        'type' => 'text_with_summary',
+        'settings' => [],
+        'cardinality' => 1,
+      ])->save();
+    }
+
+    $node_type->save();
+  }
+
+  /**
+   * Tests the selects container uses the preview-selects class.
+   *
+   * The container must use the custom .preview-selects class for the
+   * flexbox layout CSS, and must not carry the Views-specific
+   * .views-exposed-form class.
+   */
+  public function testPreviewSelectsContainerStructure(): void {
+    $formatter = $this->createFormatter('test_selects');
+    $form = $this->buildForm($formatter);
+
+    $this->assertArrayHasKey('selects', $form['preview']);
+    $this->assertContains('preview-selects', $form['preview']['selects']['#attributes']['class']);
+    $this->assertNotContains('views-exposed-form', $form['preview']['selects']['#attributes']['class']);
+  }
+
+  /**
+   * Tests the preview button is placed inside the selects container.
+   *
+   * The button must be a child of the selects container so that CSS
+   * flexbox rules include it in the horizontal layout alongside the
+   * selects.
+   */
+  public function testPreviewButtonInsideSelectsContainer(): void {
+    $formatter = $this->createFormatter('test_button');
+    $form = $this->buildForm($formatter);
+
+    $this->assertArrayHasKey('button', $form['preview']['selects']);
+    $button = $form['preview']['selects']['button'];
+    $this->assertEquals('submit', $button['#type']);
+    $this->assertEquals('primary', $button['#button_type']);
+    $this->assertContains('::previewSubmit', $button['#submit']);
+    $this->assertArrayHasKey('#ajax', $button);
+    $this->assertEquals('preview-output-wrapper', $button['#ajax']['wrapper']);
+  }
+
+  /**
+   * Tests the preview button is wrapped in a preview-actions div.
+   *
+   * The button uses #prefix/#suffix to wrap the bare <input> in a <div>
+   * with the preview-actions class, enabling flexbox layout and alignment.
+   */
+  public function testPreviewButtonWrapperClass(): void {
+    $formatter = $this->createFormatter('test_button_class');
+    $form = $this->buildForm($formatter);
+
+    $button = $form['preview']['selects']['button'];
+    $this->assertStringContainsString('preview-actions', $button['#prefix']);
+  }
+
+  /**
+   * Tests debug details group is absent when Devel is not installed.
+   *
+   * Follows the core convention of conditional element inclusion: the
+   * entire debug details group should not be rendered when Devel is not
+   * available, rather than rendered but disabled.
+   */
+  public function testDebugDetailsAbsentWithoutDevel(): void {
+    $formatter = $this->createFormatter('test_no_debug');
+    $form = $this->buildForm($formatter);
+
+    $this->assertArrayNotHasKey('debug', $form['preview']);
+  }
+
+  /**
+   * Tests the formatter_form library is attached to the form.
+   */
+  public function testPreviewLibraryAttached(): void {
+    $formatter = $this->createFormatter('test_library');
+    $form = $this->buildForm($formatter);
+
+    $this->assertContains('custom_formatters/formatter_form', $form['#attached']['library']);
+  }
+
+  /**
+   * Tests cascading selects have correct AJAX wrappers.
+   *
+   * The entity type, bundle, and field selects must all trigger an AJAX
+   * rebuild of the selects container, ensuring downstream options are
+   * recalculated when upstream selections change.
+   */
+  public function testCascadingSelectsAjax(): void {
+    $formatter = $this->createFormatter('test_ajax');
+    $form = $this->buildForm($formatter);
+
+    foreach (['entity_type', 'bundle', 'field'] as $select_name) {
+      $this->assertArrayHasKey('#ajax', $form['preview']['selects'][$select_name]);
+      $this->assertEquals('preview-selects-wrapper', $form['preview']['selects'][$select_name]['#ajax']['wrapper']);
+    }
+
+    // Entity select should NOT have AJAX (no downstream depends on it).
+    $this->assertArrayNotHasKey('#ajax', $form['preview']['selects']['entity']);
+  }
+
+  /**
+   * Tests the selects container uses an AJAX wrapper div.
+   */
+  public function testSelectsContainerAjaxWrapper(): void {
+    $formatter = $this->createFormatter('test_wrapper');
+    $form = $this->buildForm($formatter);
+
+    $selects = $form['preview']['selects'];
+    $this->assertEquals('<div id="preview-selects-wrapper">', $selects['#prefix']);
+    $this->assertEquals('</div>', $selects['#suffix']);
+  }
+
+  /**
+   * Tests preview output section has the correct AJAX wrapper.
+   */
+  public function testPreviewOutputContainerStructure(): void {
+    $formatter = $this->createFormatter('test_output');
+    $form = $this->buildForm($formatter);
+
+    $this->assertArrayHasKey('output', $form['preview']);
+    $this->assertEquals('preview-output-wrapper', $form['preview']['output']['#attributes']['id']);
+  }
+
+  /**
+   * Tests the toggle checkbox for full field theming is present.
+   */
+  public function testToggleCheckboxPresent(): void {
+    $formatter = $this->createFormatter('test_toggle');
+    $form = $this->buildForm($formatter);
+
+    $this->assertArrayHasKey('toggle', $form['preview']);
+    $this->assertEquals('checkbox', $form['preview']['toggle']['#type']);
+  }
+
+  /**
+   * Tests buildPreviewOutput uses Devel dumper when available.
+   *
+   * Debug output is wrapped in a collapsible details element with the
+   * mock dumper's output nested under the 'dump' key.
+   */
+  public function testBuildPreviewOutputWithDevelDumper(): void {
+    $formatter = $this->createFormatter('test_devel_output');
+    $formatter->save();
+
+    $form_object = $this->getFormObject($formatter);
+
+    // Create a mock dumper that returns identifiable output.
+    $mock_dumper = new class {
+
+      /**
+       * Mock exportAsRenderable returning identifiable test output.
+       */
+      public function exportAsRenderable(mixed $input, ?string $name = NULL): array {
+        return ['#markup' => 'MOCK_DEVEL_OUTPUT'];
+      }
+
+    };
+
+    // Inject the mock dumper via reflection.
+    $ref = new \ReflectionClass($form_object);
+    $prop = $ref->getProperty('develDumper');
+    $prop->setAccessible(TRUE);
+    $prop->setValue($form_object, $mock_dumper);
+
+    $output = $this->invokeBuildPreviewOutput($form_object, 'php', [
+      'debug_variables' => TRUE,
+      'debug_html' => TRUE,
+    ]);
+
+    // Debug sections should be wrapped in a container with CSS spacing.
+    $this->assertArrayHasKey('debug_variables', $output);
+    $this->assertArrayHasKey('debug_html', $output);
+    $this->assertEquals('container', $output['debug_variables']['#type']);
+    $this->assertEquals('container', $output['debug_html']['#type']);
+    $this->assertContains('formatter-preview-debug', $output['debug_variables']['#attributes']['class']);
+    $this->assertContains('formatter-preview-debug', $output['debug_html']['#attributes']['class']);
+    $this->assertEquals('MOCK_DEVEL_OUTPUT', $output['debug_variables']['dump']['#markup']);
+    $this->assertEquals('MOCK_DEVEL_OUTPUT', $output['debug_html']['dump']['#markup']);
+  }
+
+  /**
+   * Tests debug output is not added when debug settings are empty.
+   *
+   * Since the debug details group is conditionally included only when Devel
+   * is installed, the debug settings will always be empty without Devel. This
+   * test verifies that buildPreviewOutput produces no debug sections when
+   * no settings are active.
+   */
+  public function testBuildPreviewOutputWithoutDebugSettings(): void {
+    $formatter = $this->createFormatter('test_no_debug_settings');
+    $formatter->save();
+
+    $form_object = $this->getFormObject($formatter);
+
+    $output = $this->invokeBuildPreviewOutput($form_object, 'html_token', []);
+
+    $this->assertArrayHasKey('preview', $output);
+    $this->assertArrayNotHasKey('debug_variables', $output);
+    $this->assertArrayNotHasKey('debug_html', $output);
+  }
+
+  /**
+   * Tests debug_variables works for any engine type.
+   *
+   * The PHP-only gate was removed so debug_variables now produces output
+   * for all formatter types when the checkbox is enabled.
+   */
+  public function testDebugVariablesForAnyEngineType(): void {
+    $formatter = $this->createFormatter('test_any_engine');
+    $formatter->save();
+
+    $form_object = $this->getFormObject($formatter);
+
+    // Inject mock dumper so the Devel path is taken.
+    $mock_dumper = new class {
+
+      /**
+       * Mock exportAsRenderable.
+       */
+      public function exportAsRenderable(mixed $input, ?string $name = NULL): array {
+        return ['#markup' => 'MOCK'];
+      }
+
+    };
+    $ref = new \ReflectionClass($form_object);
+    $prop = $ref->getProperty('develDumper');
+    $prop->setAccessible(TRUE);
+    $prop->setValue($form_object, $mock_dumper);
+
+    // Verify debug_variables works for non-PHP engines.
+    $output = $this->invokeBuildPreviewOutput($form_object, 'html_token', [
+      'debug_variables' => TRUE,
+      'debug_html' => TRUE,
+    ]);
+
+    $this->assertArrayHasKey('debug_variables', $output);
+    $this->assertArrayHasKey('debug_html', $output);
+    $this->assertEquals('container', $output['debug_variables']['#type']);
+    $this->assertEquals('container', $output['debug_html']['#type']);
+    $this->assertContains('formatter-preview-debug', $output['debug_variables']['#attributes']['class']);
+    $this->assertContains('formatter-preview-debug', $output['debug_html']['#attributes']['class']);
+  }
+
+  /**
+   * Creates a formatter entity with basic properties.
+   *
+   * @param string $id
+   *   The formatter machine name.
+   *
+   * @return \Drupal\custom_formatters\FormatterInterface
+   *   The unsaved formatter entity.
+   */
+  private function createFormatter(string $id): FormatterInterface {
+    $formatter = $this->container->get('entity_type.manager')
+      ->getStorage('formatter')
+      ->create([
+        'id' => $id,
+        'label' => 'Test ' . $id,
+        'type' => 'html_token',
+        'field_types' => ['text'],
+        'data' => '[node:title]',
+      ]);
+    assert($formatter instanceof FormatterInterface);
+    return $formatter;
+  }
+
+  /**
+   * Builds the formatter edit form for a given formatter entity.
+   *
+   * @param \Drupal\custom_formatters\FormatterInterface $formatter
+   *   The formatter entity.
+   *
+   * @return array
+   *   The rendered form array.
+   */
+  private function buildForm(FormatterInterface $formatter): array {
+    $form_object = $this->getFormObject($formatter);
+    return $this->container->get('form_builder')->getForm($form_object);
+  }
+
+  /**
+   * Gets the FormatterForm object for a given formatter entity.
+   *
+   * @param \Drupal\custom_formatters\FormatterInterface $formatter
+   *   The formatter entity.
+   *
+   * @return \Drupal\custom_formatters\Form\FormatterForm
+   *   The form object with the entity set.
+   */
+  private function getFormObject(FormatterInterface $formatter): FormatterForm {
+    $form_object = $this->container->get('entity_type.manager')
+      ->getFormObject('formatter', 'edit');
+    assert($form_object instanceof FormatterForm);
+    $form_object->setEntity($formatter);
+    return $form_object;
+  }
+
+  /**
+   * Invokes the protected buildPreviewOutput method via reflection.
+   *
+   * @param \Drupal\custom_formatters\Form\FormatterForm $form_object
+   *   The form object.
+   * @param string $plugin_id
+   *   The formatter type plugin ID (e.g. 'php', 'html_token').
+   * @param array $settings
+   *   The preview debug settings.
+   *
+   * @return array
+   *   The preview output render array.
+   */
+  private function invokeBuildPreviewOutput(FormatterForm $form_object, string $plugin_id, array $settings): array {
+    $items = $this->createMock(FieldItemListInterface::class);
+    $items->method('getValue')->willReturn([['value' => 'test']]);
+    $items->method('getLangcode')->willReturn('en');
+
+    $entity = $this->createMock(FieldableEntityInterface::class);
+
+    $formatter_type = $this->createMock(FormatterTypeInterface::class);
+    $formatter_type->method('getPluginId')->willReturn($plugin_id);
+
+    $ref = new \ReflectionClass($form_object);
+    $method = $ref->getMethod('buildPreviewOutput');
+    $method->setAccessible(TRUE);
+
+    return $method->invoke(
+      $form_object,
+      [['#markup' => '<p>Test output</p>']],
+      $items,
+      'node',
+      'article',
+      'body',
+      $entity,
+      $settings,
+      FALSE,
+      $formatter_type
+    );
+  }
+
+}

--- a/tests/src/Kernel/FormatterPreviewFormTest.php
+++ b/tests/src/Kernel/FormatterPreviewFormTest.php
@@ -11,12 +11,17 @@ namespace Drupal\Tests\custom_formatters\Kernel;
 
 use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormState;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\custom_formatters\Form\FormatterForm;
 use Drupal\custom_formatters\FormatterInterface;
 use Drupal\custom_formatters\FormatterTypeInterface;
+use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\KernelTests\KernelTestBase;
+use Drupal\node\NodeInterface;
 use Drupal\node\NodeTypeInterface;
+use Drupal\Tests\user\Traits\UserCreationTrait;
 
 /**
  * Tests the preview section on the formatter entity form.
@@ -35,6 +40,8 @@ use Drupal\node\NodeTypeInterface;
  * @group custom_formatters
  */
 class FormatterPreviewFormTest extends KernelTestBase {
+
+  use UserCreationTrait;
 
   /**
    * {@inheritdoc}
@@ -56,6 +63,8 @@ class FormatterPreviewFormTest extends KernelTestBase {
     $this->installConfig(['custom_formatters', 'node']);
     $this->installEntitySchema('node');
     $this->installEntitySchema('user');
+    $this->installSchema('node', 'node_access');
+    node_access_rebuild();
 
     // Create an article content type so the preview selects have entity
     // types, bundles, and fields to work with.
@@ -81,6 +90,17 @@ class FormatterPreviewFormTest extends KernelTestBase {
     }
 
     $node_type->save();
+
+    // Ensure the body field config exists on the article bundle.
+    // node_node_type_insert() may skip creating it in kernel test env.
+    if (!FieldConfig::loadByName('node', 'article', 'body')) {
+      FieldConfig::create([
+        'field_name' => 'body',
+        'entity_type' => 'node',
+        'bundle' => 'article',
+        'label' => 'Body',
+      ])->save();
+    }
   }
 
   /**
@@ -321,6 +341,244 @@ class FormatterPreviewFormTest extends KernelTestBase {
   }
 
   /**
+   * Tests getPreviewDefaults returns expected default values.
+   */
+  public function testGetPreviewDefaults(): void {
+    $formatter = $this->createFormatter('test_defaults');
+    // Set field_types to include text_with_summary so body field matches.
+    $formatter->set('field_types', ['text', 'text_with_summary']);
+    $form_object = $this->getFormObject($formatter);
+
+    $ref = new \ReflectionClass($form_object);
+    $method = $ref->getMethod('getPreviewDefaults');
+    $method->setAccessible(TRUE);
+
+    $defaults = $method->invoke($form_object, new FormState());
+
+    $this->assertEquals('node', $defaults['entity_type']);
+    $this->assertEquals('article', $defaults['bundle']);
+    $this->assertEquals('body', $defaults['field']);
+  }
+
+  /**
+   * Tests getPreviewEntityTypes returns node.
+   */
+  public function testGetPreviewEntityTypes(): void {
+    $formatter = $this->createFormatter('test_entity_types');
+    $form_object = $this->getFormObject($formatter);
+
+    $ref = new \ReflectionClass($form_object);
+    $method = $ref->getMethod('getPreviewEntityTypes');
+    $method->setAccessible(TRUE);
+
+    $types = $method->invoke($form_object);
+    $this->assertArrayHasKey('node', $types);
+  }
+
+  /**
+   * Tests getPreviewBundles returns article for node.
+   */
+  public function testGetPreviewBundles(): void {
+    $formatter = $this->createFormatter('test_bundles');
+    $form_object = $this->getFormObject($formatter);
+
+    $ref = new \ReflectionClass($form_object);
+    $method = $ref->getMethod('getPreviewBundles');
+    $method->setAccessible(TRUE);
+
+    $bundles = $method->invoke($form_object, 'node');
+    $this->assertArrayHasKey('article', $bundles);
+  }
+
+  /**
+   * Tests getPreviewFields returns body for article with text types.
+   */
+  public function testGetPreviewFields(): void {
+    $formatter = $this->createFormatter('test_fields');
+    $form_object = $this->getFormObject($formatter);
+
+    $ref = new \ReflectionClass($form_object);
+    $method = $ref->getMethod('getPreviewFields');
+    $method->setAccessible(TRUE);
+
+    $fields = $method->invoke($form_object, 'node', 'article', ['text', 'text_with_summary']);
+    $this->assertArrayHasKey('body', $fields);
+  }
+
+  /**
+   * Tests buildPreviewOutput with toggle=true hits field theming path.
+   */
+  public function testBuildPreviewOutputWithToggle(): void {
+    $formatter = $this->createFormatter('test_toggle_debug');
+    $formatter->save();
+    $form_object = $this->getFormObject($formatter);
+
+    $output = $this->invokeBuildPreviewOutput($form_object, 'html_token', [], TRUE);
+
+    $this->assertArrayHasKey('preview', $output);
+    $this->assertArrayHasKey('content', $output['preview']);
+    $this->assertNotEmpty($output['preview']['content']['#markup']);
+  }
+
+  /**
+   * Tests Php::previewDebugData() returns $items->getValue().
+   */
+  public function testPhpPreviewDebugData(): void {
+    $formatter = $this->container->get('entity_type.manager')
+      ->getStorage('formatter')
+      ->create([
+        'id' => 'test_php_debug',
+        'label' => 'Test PHP Debug',
+        'type' => 'php',
+        'field_types' => ['text'],
+        'data' => 'return "test";',
+      ]);
+    $formatter->save();
+    $plugin = $formatter->getFormatterType();
+
+    $items = $this->createMock(FieldItemListInterface::class);
+    $items->method('getValue')->willReturn([['value' => 'php test']]);
+
+    $entity = $this->createMock(FieldableEntityInterface::class);
+
+    $data = $plugin->previewDebugData($items, $entity);
+    $this->assertEquals([['value' => 'php test']], $data);
+  }
+
+  /**
+   * Tests Twig::previewDebugData() returns bundled data.
+   */
+  public function testTwigPreviewDebugData(): void {
+    $formatter = $this->container->get('entity_type.manager')
+      ->getStorage('formatter')
+      ->create([
+        'id' => 'test_twig_debug',
+        'label' => 'Test Twig Debug',
+        'type' => 'twig',
+        'field_types' => ['text'],
+        'data' => '{{ items }}',
+      ]);
+    $formatter->save();
+    $plugin = $formatter->getFormatterType();
+
+    $items = $this->createMock(FieldItemListInterface::class);
+    $items->method('getValue')->willReturn([['value' => 'twig test']]);
+    $items->method('getLangcode')->willReturn('en');
+
+    $entity = $this->createMock(FieldableEntityInterface::class);
+
+    $data = $plugin->previewDebugData($items, $entity);
+    $this->assertArrayHasKey('items', $data);
+    $this->assertArrayHasKey('langcode', $data);
+    $this->assertArrayHasKey('entity', $data);
+    $this->assertEquals('en', $data['langcode']);
+    $this->assertSame($entity, $data['entity']);
+  }
+
+  /**
+   * Tests HTMLToken::previewDebugData() returns $entity.
+   */
+  public function testHtmlTokenPreviewDebugData(): void {
+    $formatter = $this->container->get('entity_type.manager')
+      ->getStorage('formatter')
+      ->create([
+        'id' => 'test_html_token_debug',
+        'label' => 'Test HTMLToken Debug',
+        'type' => 'html_token',
+        'field_types' => ['text'],
+        'data' => '[node:title]',
+      ]);
+    $formatter->save();
+    $plugin = $formatter->getFormatterType();
+
+    $items = $this->createMock(FieldItemListInterface::class);
+    $entity = $this->createMock(FieldableEntityInterface::class);
+
+    $data = $plugin->previewDebugData($items, $entity);
+    $this->assertSame($entity, $data);
+  }
+
+  /**
+   * Tests getPreviewEntities returns nodes with body field data.
+   */
+  public function testGetPreviewEntities(): void {
+    $user = $this->createUser(['bypass node access']);
+    assert($user instanceof AccountInterface);
+    $this->container->get('current_user')->setAccount($user);
+
+    $node = $this->container->get('entity_type.manager')
+      ->getStorage('node')
+      ->create([
+        'type' => 'article',
+        'title' => 'Test preview entity',
+        'body' => 'Some body text',
+      ]);
+    assert($node instanceof NodeInterface);
+    $node->save();
+
+    $formatter = $this->createFormatter('test_get_entities');
+    $form_object = $this->getFormObject($formatter);
+
+    $ref = new \ReflectionClass($form_object);
+    $method = $ref->getMethod('getPreviewEntities');
+    $method->setAccessible(TRUE);
+
+    $entities = $method->invoke($form_object, 'node', 'article', 'body');
+    $this->assertNotEmpty($entities);
+    $this->assertArrayHasKey($node->id(), $entities);
+  }
+
+  /**
+   * Tests previewSelectsAjax returns the selects container.
+   */
+  public function testPreviewSelectsAjax(): void {
+    $formatter = $this->createFormatter('test_ajax_selects');
+    $form_object = $this->getFormObject($formatter);
+    $form = $this->container->get('form_builder')->getForm($form_object);
+
+    $form_state = new FormState();
+    $result = $form_object->previewSelectsAjax($form, $form_state);
+
+    $this->assertArrayHasKey('entity_type', $result);
+    $this->assertArrayHasKey('bundle', $result);
+    $this->assertArrayHasKey('field', $result);
+    $this->assertArrayHasKey('entity', $result);
+  }
+
+  /**
+   * Tests previewAjaxCallback returns the output container.
+   */
+  public function testPreviewAjaxCallback(): void {
+    $formatter = $this->createFormatter('test_ajax_output');
+    $form_object = $this->getFormObject($formatter);
+    $form = $this->container->get('form_builder')->getForm($form_object);
+
+    $form_state = new FormState();
+    $result = $form_object->previewAjaxCallback($form, $form_state);
+
+    $this->assertEquals('container', $result['#type']);
+  }
+
+  /**
+   * Tests previewSubmit with incomplete selections sets warning message.
+   */
+  public function testPreviewSubmitIncompleteSelections(): void {
+    $formatter = $this->createFormatter('test_incomplete_submit');
+    $form_object = $this->getFormObject($formatter);
+    $this->container->get('form_builder')->getForm($form_object);
+
+    $form_state = new FormState();
+    $form_state->setValue(['preview', 'selects', 'entity_type'], 'node');
+    $form_state->setValue(['preview', 'selects', 'bundle'], '');
+
+    $form_object->previewSubmit([], $form_state);
+
+    $output = $form_state->get('preview_output');
+    $this->assertNotNull($output);
+    $this->assertEquals('status_messages', $output['#theme']);
+  }
+
+  /**
    * Creates a formatter entity with basic properties.
    *
    * @param string $id
@@ -383,11 +641,13 @@ class FormatterPreviewFormTest extends KernelTestBase {
    *   The formatter type plugin ID (e.g. 'php', 'html_token').
    * @param array $settings
    *   The preview debug settings.
+   * @param bool $toggle
+   *   Whether to render with full field theming.
    *
    * @return array
    *   The preview output render array.
    */
-  private function invokeBuildPreviewOutput(FormatterForm $form_object, string $plugin_id, array $settings): array {
+  private function invokeBuildPreviewOutput(FormatterForm $form_object, string $plugin_id, array $settings, bool $toggle = FALSE): array {
     $items = $this->createMock(FieldItemListInterface::class);
     $items->method('getValue')->willReturn([['value' => 'test']]);
     $items->method('getLangcode')->willReturn('en');
@@ -410,7 +670,7 @@ class FormatterPreviewFormTest extends KernelTestBase {
       'body',
       $entity,
       $settings,
-      FALSE,
+      $toggle,
       $formatter_type
     );
   }


### PR DESCRIPTION
## Summary
Adds a live preview panel to the Custom Formatters formatter edit form, allowing
users to test formatter output against real field data before saving. Includes
per-engine debug options (variable dumps, HTML output) via Devel integration.
## Changes
### Preview UI (`src/Form/FormatterForm.php`)
- New preview fieldset in `additional_settings` vertical tabs tab
- Cascading AJAX selects: entity type → bundle → field → entity
- Pre-selection defaults to Node → first bundle → first matching field → first entity
- Preview button (`#type => submit`) triggers inline AJAX rebuild
- Full field theming toggle for rendered-field vs raw-element output
- All selects use conditional `#empty_option` for consistent layout (no `#description` text)
### Per-engine debug settings
- `previewSettingsForm()` on `FormatterTypeInterface` / `FormatterTypeBase`
- **PHP**: `debug_variables` (dumps `$items->getValue()`) and `debug_html`
- **Twig**: `debug_variables` (dumps `items`, `langcode`, `entity`), `debug_html`
- **HTML+Token**: `debug_variables` (dumps entity for token context), `debug_html`
- **Formatter Preset**: `debug_html` only
- Debug checkboxes disabled when Devel is not installed
- Conditional inclusion of Debugging details group via `moduleExists('devel')`
- Devel dumper (`devel.dumper`) injected with `NULL_ON_INVALID_REFERENCE`
### Visual layout (`styles/custom_formatters.css`, `custom_formatters.libraries.yml`)
- `.preview-selects` flexbox container (not piggybacking on Claro's `views-exposed-form` CSS)
- `.preview-actions` wrapping the Preview button for correct inline alignment
- `.formatter-preview-output` styled preview container (white background, border, padding)
- `.formatter-preview-debug` spacing for Devel dumper output
- `formatter_form` library with own CSS, no Claro dependency
### Rendering (`custom_formatters.module`, `templates/formatter-preview.html.twig`)
- `formatter_preview` theme hook registered
- Template renders preview output inside a `#preview-wrapper` container
### Testing (`tests/src/Kernel/FormatterPreviewFormTest.php`)
- 12 kernel tests covering: selects container, button placement, button wrapper class,
  debug conditional inclusion, library attachment, cascading AJAX, AJAX wrapper,
  preview output container, toggle checkbox, Devel dumper integration, no-debug
  settings, and per-engine debug_variables output
- 42 total tests, 422 assertions, 0 failures
### Build & CI
- `drupal/devel` added to `composer.json` suggest section
- `phpstan.neon` updated for FieldItemListInterface generic type ignores
---
## Testing
1. Edit any Custom Formatter
2. Expand the **Preview** tab in the vertical tabs sidebar
3. Select entity type, bundle, field, and entity
4. Click **Preview** to see rendered output
5. Enable debug options (requires Devel module):
   - **Output variables** — dumps template variables via `dpm()`-style output
   - **Output raw HTML** — shows the markup before theme wrapping
6. Toggle **Show full field theming** to compare raw vs themed output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Formatter preview UI on the formatter edit form with cascading entity/bundle/field selectors, AJAX preview, and a "Show full field theming" toggle; Devel‑gated debug options for variables and raw HTML.

* **Styles**
  * UI styles and a frontend library added for the preview controls and output.

* **Templates**
  * New preview template for rendering preview output.

* **Tests**
  * Comprehensive kernel tests covering preview UI, AJAX behavior, and debug output.

* **Chores**
  * Suggested Devel package added/ordering updated in package metadata.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Decipher/custom_formatters/pull/10?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->