### PR TITLE
feat: add optional CodeMirror integration for formatter code editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Recommended Modules
 
 * [Token](https://www.drupal.org/project/token)
 * [Field tokens](https://www.drupal.org/project/field_tokens)
+* [CodeMirror Editor](https://www.drupal.org/project/codemirror_editor) — Provides syntax-highlighted code editing for the PHP, HTML+Token, and Twig formatter engines.
 
 
 
@@ -89,5 +90,5 @@ TODOs / Roadmap
 * Set usages of formatters to default formatter on deletion.
 * ~~Re-add save & edit?~~ (Added in 4.1.x)
 * Re-add preview.
-  - Replace EditArea with a modern code editor (CodeMirror, Monaco Editor).
+* ~~Replace EditArea with a modern code editor.~~ (Added in 4.1.x, via [CodeMirror Editor](https://www.drupal.org/project/codemirror_editor))
 * Re-add export?

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "drupal/token": "^1"
     },
     "suggest": {
-        "drupal/token": "Provides token replacement support for the HTML Token formatter type."
+        "drupal/token": "Provides token replacement support for the HTML Token formatter type.",
+        "drupal/codemirror_editor": "Provides syntax-highlighted code editing via CodeMirror for the PHP, HTML+Token, and Twig formatter engines."
     }
 }

--- a/src/FormatterTypeBase.php
+++ b/src/FormatterTypeBase.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Drupal\custom_formatters;
 
+use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Plugin\PluginBase;
@@ -27,10 +28,18 @@ abstract class FormatterTypeBase extends PluginBase implements FormatterTypeInte
   protected $entity = NULL;
 
   /**
+   * The module handler service.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected ModuleHandlerInterface $moduleHandler;
+
+  /**
    * {@inheritdoc}
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, ModuleHandlerInterface $module_handler) {
     $this->entity = $configuration['entity'];
+    $this->moduleHandler = $module_handler;
     parent::__construct($configuration, $plugin_id, $plugin_definition);
   }
 
@@ -38,7 +47,7 @@ abstract class FormatterTypeBase extends PluginBase implements FormatterTypeInte
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static($configuration, $plugin_id, $plugin_definition);
+    return new static($configuration, $plugin_id, $plugin_definition, $container->get('module_handler'));
   }
 
   /**
@@ -52,15 +61,71 @@ abstract class FormatterTypeBase extends PluginBase implements FormatterTypeInte
    * {@inheritdoc}
    */
   public function settingsForm(array &$form, FormStateInterface $form_state): array {
-    $form['data'] = [
+    $form['data'] = $this->buildCodeEditorElement($this->getCodeEditorMode());
+
+    return $form;
+  }
+
+  /**
+   * Returns the CodeMirror language mode for this engine.
+   *
+   * Override in child classes to enable CodeMirror integration. Return NULL
+   * to use a plain textarea regardless of module availability.
+   *
+   * @return string|null
+   *   A CodeMirror mode string (e.g. 'application/x-httpd-php'), or NULL.
+   */
+  protected function getCodeEditorMode(): ?string {
+    return NULL;
+  }
+
+  /**
+   * Returns extra CodeMirror options specific to this engine.
+   *
+   * Override in child classes to add engine-specific settings like
+   * autoCloseTags.
+   *
+   * @return array
+   *   An associative array of CodeMirror options.
+   */
+  protected function getCodeMirrorExtraSettings(): array {
+    return [];
+  }
+
+  /**
+   * Builds a code editor form element.
+   *
+   * Uses CodeMirror when the codemirror_editor module is installed and a mode
+   * is provided. Falls back to a plain textarea otherwise.
+   *
+   * @param string|null $mode
+   *   The CodeMirror language mode, or NULL for plain textarea.
+   *
+   * @return array
+   *   A render array for the code editor form element.
+   */
+  protected function buildCodeEditorElement(?string $mode = NULL): array {
+    $has_codemirror = $mode !== NULL && $this->moduleHandler->moduleExists('codemirror_editor');
+
+    $element = [
       '#title'         => $this->t('Formatter'),
-      '#type'          => 'textarea',
+      '#type'          => $has_codemirror ? 'codemirror' : 'textarea',
       '#default_value' => $this->entity->get('data'),
       '#required'      => TRUE,
       '#rows'          => 10,
     ];
 
-    return $form;
+    if ($has_codemirror) {
+      $element['#codemirror'] = [
+        'mode'             => $mode,
+        'lineNumbers'      => TRUE,
+        'lineWrapping'     => TRUE,
+        'styleActiveLine'  => TRUE,
+        'toolbar'          => FALSE,
+      ] + $this->getCodeMirrorExtraSettings();
+    }
+
+    return $element;
   }
 
   /**

--- a/src/Plugin/CustomFormatters/FormatterType/FormatterPreset.php
+++ b/src/Plugin/CustomFormatters/FormatterType/FormatterPreset.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Drupal\custom_formatters\Plugin\CustomFormatters\FormatterType;
 
 use Drupal\Component\Plugin\DependentPluginInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Field\FormatterInterface;
@@ -40,8 +41,8 @@ class FormatterPreset extends FormatterTypeBase {
   /**
    * {@inheritdoc}
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, FormatterPluginManager $formatter_manager) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, ModuleHandlerInterface $module_handler, FormatterPluginManager $formatter_manager) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $module_handler);
     $this->formatterManager = $formatter_manager;
   }
 
@@ -49,7 +50,7 @@ class FormatterPreset extends FormatterTypeBase {
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static($configuration, $plugin_id, $plugin_definition, $container->get('plugin.manager.field.formatter'));
+    return new static($configuration, $plugin_id, $plugin_definition, $container->get('module_handler'), $container->get('plugin.manager.field.formatter'));
   }
 
   /**

--- a/src/Plugin/CustomFormatters/FormatterType/HTMLToken.php
+++ b/src/Plugin/CustomFormatters/FormatterType/HTMLToken.php
@@ -31,6 +31,20 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class HTMLToken extends FormatterTypeBase {
 
   /**
+   * {@inheritdoc}
+   */
+  protected function getCodeEditorMode(): ?string {
+    return 'text/html';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getCodeMirrorExtraSettings(): array {
+    return ['autoCloseTags' => TRUE];
+  }
+
+  /**
    * The module handler service.
    */
   protected ModuleHandlerInterface $moduleHandler;
@@ -49,7 +63,7 @@ class HTMLToken extends FormatterTypeBase {
    * {@inheritdoc}
    */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, ModuleHandlerInterface $module_handler, EntityTypeManagerInterface $entity_type_manager, Token $token_service) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $module_handler);
     $this->moduleHandler = $module_handler;
     $this->entityTypeManager = $entity_type_manager;
     $this->tokenService = $token_service;

--- a/src/Plugin/CustomFormatters/FormatterType/Php.php
+++ b/src/Plugin/CustomFormatters/FormatterType/Php.php
@@ -33,6 +33,13 @@ class Php extends FormatterTypeBase {
   /**
    * {@inheritdoc}
    */
+  protected function getCodeEditorMode(): ?string {
+    return 'application/x-httpd-php';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function settingsForm(array &$form, FormStateInterface $form_state): array {
     $form = parent::settingsForm($form, $form_state);
 

--- a/src/Plugin/CustomFormatters/FormatterType/Twig.php
+++ b/src/Plugin/CustomFormatters/FormatterType/Twig.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Drupal\custom_formatters\Plugin\CustomFormatters\FormatterType;
 
+use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\custom_formatters\FormatterTypeBase;
@@ -28,6 +29,20 @@ use Twig\Error\Error;
 class Twig extends FormatterTypeBase {
 
   /**
+   * {@inheritdoc}
+   */
+  protected function getCodeEditorMode(): ?string {
+    return 'twig';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getCodeMirrorExtraSettings(): array {
+    return ['autoCloseTags' => TRUE];
+  }
+
+  /**
    * The Twig environment service.
    */
   protected Environment $twigService;
@@ -35,8 +50,8 @@ class Twig extends FormatterTypeBase {
   /**
    * {@inheritdoc}
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, Environment $twig_service) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, ModuleHandlerInterface $module_handler, Environment $twig_service) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $module_handler);
     $this->twigService = $twig_service;
   }
 
@@ -44,7 +59,7 @@ class Twig extends FormatterTypeBase {
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static($configuration, $plugin_id, $plugin_definition, $container->get('twig'));
+    return new static($configuration, $plugin_id, $plugin_definition, $container->get('module_handler'), $container->get('twig'));
   }
 
   /**

--- a/tests/src/Kernel/CodeMirrorEditorTest.php
+++ b/tests/src/Kernel/CodeMirrorEditorTest.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @file
+ * Kernel tests for CodeMirror editor integration in formatter type plugins.
+ */
+
+namespace Drupal\Tests\custom_formatters\Kernel;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormState;
+use Drupal\custom_formatters\FormatterInterface;
+use Drupal\custom_formatters\FormatterTypeBase;
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Tests CodeMirror editor integration for formatter type plugins.
+ *
+ * Verifies that engine plugins produce CodeMirror form elements when the
+ * codemirror_editor module is installed, and plain textarea elements when
+ * it is not.
+ *
+ * @group custom_formatters
+ */
+class CodeMirrorEditorTest extends KernelTestBase {
+
+  /**
+   * Modules to enable.
+   *
+   * @var string[]
+   */
+  protected static $modules = ['custom_formatters', 'field', 'system', 'user'];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installConfig('custom_formatters');
+  }
+
+  /**
+   * Tests PHP engine falls back to textarea without codemirror_editor.
+   */
+  public function testPhpEngineFallbackTextarea(): void {
+    $form = $this->buildSettingsForm('php', 'test_php_fallback');
+    $this->assertSame('textarea', $form['data']['#type']);
+    $this->assertArrayNotHasKey('#codemirror', $form['data']);
+  }
+
+  /**
+   * Tests HTML+Token engine falls back to textarea without codemirror_editor.
+   */
+  public function testHtmlTokenEngineFallbackTextarea(): void {
+    $form = $this->buildSettingsForm('html_token', 'test_html_fallback');
+    $this->assertSame('textarea', $form['data']['#type']);
+    $this->assertArrayNotHasKey('#codemirror', $form['data']);
+  }
+
+  /**
+   * Tests Twig engine falls back to textarea without codemirror_editor.
+   */
+  public function testTwigEngineFallbackTextarea(): void {
+    $form = $this->buildSettingsForm('twig', 'test_twig_fallback');
+    $this->assertSame('textarea', $form['data']['#type']);
+    $this->assertArrayNotHasKey('#codemirror', $form['data']);
+  }
+
+  /**
+   * Tests PHP engine uses CodeMirror with PHP mode when available.
+   */
+  public function testPhpEngineWithCodeMirror(): void {
+    $this->installCodeMirror();
+    $form = $this->buildSettingsForm('php', 'test_php_cm');
+
+    $this->assertSame('codemirror', $form['data']['#type']);
+    $this->assertCodeMirrorSettings($form['data'], 'application/x-httpd-php');
+    $this->assertArrayNotHasKey('autoCloseTags', $form['data']['#codemirror']);
+  }
+
+  /**
+   * Tests HTML+Token engine uses CodeMirror with HTML mode and auto-close tags.
+   */
+  public function testHtmlTokenEngineWithCodeMirror(): void {
+    $this->installCodeMirror();
+    $form = $this->buildSettingsForm('html_token', 'test_html_cm');
+
+    $this->assertSame('codemirror', $form['data']['#type']);
+    $this->assertCodeMirrorSettings($form['data'], 'text/html');
+    $this->assertTrue($form['data']['#codemirror']['autoCloseTags']);
+  }
+
+  /**
+   * Tests Twig engine uses CodeMirror with Twig mode and auto-close tags.
+   */
+  public function testTwigEngineWithCodeMirror(): void {
+    $this->installCodeMirror();
+    $form = $this->buildSettingsForm('twig', 'test_twig_cm');
+
+    $this->assertSame('codemirror', $form['data']['#type']);
+    $this->assertCodeMirrorSettings($form['data'], 'twig');
+    $this->assertTrue($form['data']['#codemirror']['autoCloseTags']);
+  }
+
+  /**
+   * Tests Formatter Preset engine is unaffected by codemirror_editor.
+   */
+  public function testFormatterPresetNotAffectedByCodeMirror(): void {
+    $this->installCodeMirror();
+    $formatter_type = $this->createFormatter('test_preset_cm', 'formatter_preset')->getFormatterType();
+    \assert($formatter_type !== FALSE);
+    $form = [];
+    $form_state = new FormState();
+    $form_state->setValue('field_types', 'text');
+    $result = $formatter_type->settingsForm($form, $form_state);
+
+    $this->assertSame('container', $result['data']['#type']);
+    $this->assertArrayNotHasKey('#codemirror', $result['data']);
+  }
+
+  /**
+   * Tests that base class defaults produce a plain textarea element.
+   */
+  public function testBaseClassDefaultsToTextarea(): void {
+    $formatter = $this->createFormatter('test_base_default', 'php');
+    $plugin = new class(
+      ['entity' => $formatter],
+      'test',
+      ['id' => 'test', 'label' => 'Test'],
+      \Drupal::service('module_handler'),
+    ) extends FormatterTypeBase {
+
+      /**
+       * {@inheritdoc}
+       *
+       * @param \Drupal\Core\Field\FieldItemListInterface<\Drupal\Core\Field\FieldItemInterface> $items
+       *   The field values to be rendered.
+       * @param string $langcode
+       *   The language that should be used to render the field.
+       *
+       * @return array
+       *   A renderable array.
+       */
+      public function viewElements(FieldItemListInterface $items, $langcode): array {
+        return [];
+      }
+
+    };
+
+    $form = [];
+    $form_state = new FormState();
+    $result = $plugin->settingsForm($form, $form_state);
+
+    $this->assertSame('textarea', $result['data']['#type']);
+    $this->assertArrayNotHasKey('#codemirror', $result['data']);
+  }
+
+  /**
+   * Builds a settings form for a given engine type.
+   *
+   * @param string $engine_type
+   *   The formatter engine plugin ID.
+   * @param string $id
+   *   The formatter config entity ID.
+   *
+   * @return array
+   *   The rendered form array.
+   */
+  private function buildSettingsForm(string $engine_type, string $id): array {
+    $formatter_type = $this->createFormatter($id, $engine_type)->getFormatterType();
+    \assert($formatter_type !== FALSE);
+    $form = [];
+    $form_state = new FormState();
+    return $formatter_type->settingsForm($form, $form_state);
+  }
+
+  /**
+   * Creates a formatter config entity.
+   *
+   * @param string $id
+   *   The formatter config entity ID.
+   * @param string $type
+   *   The formatter engine plugin ID.
+   *
+   * @return \Drupal\custom_formatters\FormatterInterface
+   *   The created formatter entity.
+   */
+  private function createFormatter(string $id, string $type): FormatterInterface {
+    $formatter = \Drupal::entityTypeManager()->getStorage('formatter')->create([
+      'id' => $id,
+      'label' => 'Test ' . $id,
+      'type' => $type,
+      'field_types' => ['text'],
+      'data' => 'test data',
+    ]);
+    \assert($formatter instanceof FormatterInterface);
+    return $formatter;
+  }
+
+  /**
+   * Enables the codemirror_editor module for testing.
+   */
+  private function installCodeMirror(): void {
+    if (!\Drupal::service('extension.list.module')->exists('codemirror_editor')) {
+      $this->markTestSkipped('The codemirror_editor module is not available.');
+    }
+    $this->enableModules(['codemirror_editor']);
+  }
+
+  /**
+   * Asserts common CodeMirror settings on a form element.
+   *
+   * @param array $element
+   *   The form element to inspect.
+   * @param string $expected_mode
+   *   The expected CodeMirror language mode.
+   */
+  private function assertCodeMirrorSettings(array $element, string $expected_mode): void {
+    $this->assertArrayHasKey('#codemirror', $element);
+
+    $settings = $element['#codemirror'];
+    $this->assertSame($expected_mode, $settings['mode']);
+    $this->assertTrue($settings['lineNumbers']);
+    $this->assertTrue($settings['lineWrapping']);
+    $this->assertTrue($settings['styleActiveLine']);
+    $this->assertFalse($settings['toolbar']);
+  }
+
+}


### PR DESCRIPTION
## Summary
Adds optional CodeMirror editor integration for the PHP, HTML+Token, and Twig formatter engine settings forms. When the `codemirror_editor` contrib module is installed, the plain `<textarea>` elements are replaced with syntax-highlighted CodeMirror editors. Without the module, everything falls back to plain textareas — fully backward compatible, zero disruption.
## Changes
- **`FormatterTypeBase`** — New `buildCodeEditorElement()` helper that returns `#type => 'codemirror'` or `#type => 'textarea'` based on module availability. Two new overridable methods: `getCodeEditorMode()` and `getCodeMirrorExtraSettings()` for per-engine configuration. `ModuleHandlerInterface` injected via DI.
- **PHP engine** — `application/x-httpd-php` mode with line numbers, active line highlighting.
- **HTML+Token engine** — `text/html` mode with `autoCloseTags`.
- **Twig engine** — `twig` mode with `autoCloseTags`.
- **FormatterPreset** — Unaffected (doesn't use the code editor textarea).
- **`composer.json`** — `codemirror_editor` added to `suggest`.
- **README** — Added to Recommended Modules, roadmap item marked done.
## Testing
- **7 new kernel tests** covering all engines with and without `codemirror_editor`:
  - Fallback to `<textarea>` for PHP, HTML+Token, Twig (3 tests)
  - CodeMirror element with correct mode and settings for each engine (3 tests)
  - FormatterPreset unaffected by CodeMirror (1 test)
- **37/37 tests passing** (was 30), **all lint clean** (PHPCS, PHPStan, Rector, ESLint)
## Dependencies
- **Optional**: [`codemirror_editor`](https://www.drupal.org/project/codemirror_editor) (~3,857 sites, D10/D11 compatible). Falls back gracefully when not installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional syntax-highlighted code editing for PHP, HTML+Token, and Twig formatters via CodeMirror Editor integration
  * Automatically falls back to standard text editing when CodeMirror Editor module is not installed

* **Documentation**
  * Updated README to reflect CodeMirror Editor support and completion of editor modernization

* **Tests**
  * Added test suite validating CodeMirror Editor integration with formatter engines

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Decipher/custom_formatters/pull/11?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->