### PR TITLE
 Add Devel Generate integration for preview form

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ Features
   * **Token**
     Adds the Token tree browser to the HTML + Tokens engine with automatic
     entity reference token support.
+  * **Devel Generate** _(optional)_
+    Generates sample entities with dummy field data for the live preview
+    system when no real entities exist with the target field type.
 
 Recommended Modules
 -------------------
@@ -39,6 +42,8 @@ Recommended Modules
 * [CodeMirror Editor](https://www.drupal.org/project/codemirror_editor) —
   Provides syntax-highlighted code editing for the PHP, HTML+Token, and Twig
   formatter engines.
+* [Devel](https://www.drupal.org/project/devel) — Provides the Devel Generate
+  sub-module for generating sample preview entities.
 
 Usage/Configuration
 -------------------
@@ -75,7 +80,7 @@ TODOs / Roadmap
 * Add ability to change field types that aren't in use.
 * Set usages of formatters to default formatter on deletion.
 * ~~Re-add save & edit?~~ (Added in 4.1.x)
-* Re-add preview.
+* ~~Re-add preview.~~ (Added in 4.1.x)
 * ~~Replace EditArea with a modern code editor.~~ (Added in 4.1.x, via
   [CodeMirror Editor](https://www.drupal.org/project/codemirror_editor))
 * Re-add export?

--- a/custom_formatters.info.yml
+++ b/custom_formatters.info.yml
@@ -3,6 +3,8 @@ description: Allows users to easily define custom Field Formatters.
 type: module
 dependencies:
   - drupal:field
+test_dependencies:
+  - devel:devel
 package: Fields
 configure: entity.formatter.collection
 core_version_requirement: ^8.8 || ^9 || ^10 || ^11

--- a/custom_formatters.services.yml
+++ b/custom_formatters.services.yml
@@ -1,4 +1,10 @@
 services:
+  custom_formatters.devel_generate_integration:
+    class: Drupal\custom_formatters\DevelGenerateIntegration
+    arguments:
+      - '@entity_type.manager'
+      - '@entity_type.bundle.info'
+      - '@module_handler'
   custom_formatters.dependency_builder:
     class: Drupal\custom_formatters\FormatterDependencyBuilder
     arguments:

--- a/src/DevelGenerateIntegration.php
+++ b/src/DevelGenerateIntegration.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @file
+ * Devel Generate integration for preview sample data generation.
+ */
+
+namespace Drupal\custom_formatters;
+
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\FieldableEntityInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Field\FieldConfigInterface;
+
+/**
+ * Provides Devel Generate integration for generating preview sample entities.
+ */
+class DevelGenerateIntegration {
+
+  /**
+   * The entity type manager service.
+   */
+  protected EntityTypeManagerInterface $entityTypeManager;
+
+  /**
+   * The entity type bundle info service.
+   */
+  protected EntityTypeBundleInfoInterface $entityTypeBundleInfo;
+
+  /**
+   * The module handler service.
+   */
+  protected ModuleHandlerInterface $moduleHandler;
+
+  /**
+   * Constructs a DevelGenerateIntegration object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager service.
+   * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entity_type_bundle_info
+   *   The entity type bundle info service.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler service.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, EntityTypeBundleInfoInterface $entity_type_bundle_info, ModuleHandlerInterface $module_handler) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->entityTypeBundleInfo = $entity_type_bundle_info;
+    $this->moduleHandler = $module_handler;
+  }
+
+  /**
+   * Checks whether Devel Generate is available.
+   */
+  public function isAvailable(): bool {
+    return $this->moduleHandler->moduleExists('devel_generate');
+  }
+
+  /**
+   * Checks whether an entity type is supported for sample generation.
+   */
+  public function isEntityTypeSupported(string $entity_type_id): bool {
+    return in_array($entity_type_id, ['node', 'taxonomy_term', 'user', 'media'], TRUE);
+  }
+
+  /**
+   * Generates a transient sample entity with populated field data.
+   *
+   * The entity is created in memory only — it is NOT saved to the database.
+   * This matches the D7 behavior where Devel Generate produced temporary
+   * objects for preview purposes.
+   *
+   * @param string $entity_type_id
+   *   The entity type ID.
+   * @param string $bundle
+   *   The bundle ID.
+   *
+   * @return \Drupal\Core\Entity\FieldableEntityInterface|null
+   *   The generated entity object, or NULL on failure.
+   */
+  public function generateEntity(string $entity_type_id, string $bundle): ?FieldableEntityInterface {
+    if (!$this->isAvailable() || !$this->isEntityTypeSupported($entity_type_id)) {
+      return NULL;
+    }
+
+    try {
+      $storage = $this->entityTypeManager->getStorage($entity_type_id);
+      $entity_type = $this->entityTypeManager->getDefinition($entity_type_id);
+
+      $values = [];
+      if ($bundle_key = $entity_type->getKey('bundle')) {
+        $values[$bundle_key] = $bundle;
+      }
+
+      switch ($entity_type_id) {
+        case 'node':
+          $values['title'] = 'Sample ' . $this->getBundleLabel($entity_type_id, $bundle);
+          $values['status'] = 1;
+          break;
+
+        case 'taxonomy_term':
+          $values['name'] = 'Sample ' . $this->getBundleLabel($entity_type_id, $bundle);
+          break;
+
+        case 'user':
+          $values['name'] = 'sample_user';
+          $values['mail'] = 'sample@example.com';
+          $values['status'] = 1;
+          break;
+
+        case 'media':
+          $values['name'] = 'Sample ' . $this->getBundleLabel($entity_type_id, $bundle);
+          $values['status'] = 1;
+          break;
+      }
+
+      $entity = $storage->create($values);
+      assert($entity instanceof FieldableEntityInterface);
+
+      foreach ($entity->getFieldDefinitions() as $field_name => $definition) {
+        if ($definition instanceof FieldConfigInterface && $entity->hasField($field_name)) {
+          $field = $entity->get($field_name);
+          if ($field->isEmpty()) {
+            try {
+              $field->generateSampleItems();
+            }
+            catch (\Exception) {
+              // Some field types may not support sample generation.
+            }
+          }
+        }
+      }
+
+      return $entity;
+    }
+    catch (\Exception) {
+      return NULL;
+    }
+  }
+
+  /**
+   * Returns the human-readable label for a bundle.
+   */
+  protected function getBundleLabel(string $entity_type_id, string $bundle): string {
+    $bundle_info = $this->entityTypeBundleInfo->getBundleInfo($entity_type_id);
+    return $bundle_info[$bundle]['label'] ?? $bundle;
+  }
+
+}

--- a/src/DevelGenerateIntegration.php
+++ b/src/DevelGenerateIntegration.php
@@ -126,7 +126,7 @@ class DevelGenerateIntegration {
             try {
               $field->generateSampleItems();
             }
-            catch (\Exception) {
+            catch (\Throwable) {
               // Some field types may not support sample generation.
             }
           }
@@ -135,7 +135,7 @@ class DevelGenerateIntegration {
 
       return $entity;
     }
-    catch (\Exception) {
+    catch (\Throwable) {
       return NULL;
     }
   }

--- a/src/Form/FormatterForm.php
+++ b/src/Form/FormatterForm.php
@@ -87,6 +87,13 @@ class FormatterForm extends EntityForm {
   protected $develDumper = NULL;
 
   /**
+   * The Devel Generate integration service, or NULL if not available.
+   *
+   * @var \Drupal\custom_formatters\DevelGenerateIntegration|null
+   */
+  protected $develGenerateIntegration = NULL;
+
+  /**
    * Constructs a FormatterForm object.
    *
    * @param \Drupal\custom_formatters\FormatterExtrasManager $formatter_extras_manager
@@ -103,8 +110,10 @@ class FormatterForm extends EntityForm {
    *   The renderer service.
    * @param \Drupal\devel\DevelDumperManagerInterface|null $devel_dumper
    *   The Devel dumper service, or NULL if Devel is not installed.
+   * @param \Drupal\custom_formatters\DevelGenerateIntegration|null $devel_generate_integration
+   *   The Devel Generate integration service, or NULL if not available.
    */
-  public function __construct(FormatterExtrasManager $formatter_extras_manager, FormatterPluginManager $field_formatter_manager, FieldTypePluginManagerInterface $field_type_manager, EntityFieldManagerInterface $entity_field_manager, EntityTypeBundleInfoInterface $entity_type_bundle_info, RendererInterface $renderer, $devel_dumper = NULL) {
+  public function __construct(FormatterExtrasManager $formatter_extras_manager, FormatterPluginManager $field_formatter_manager, FieldTypePluginManagerInterface $field_type_manager, EntityFieldManagerInterface $entity_field_manager, EntityTypeBundleInfoInterface $entity_type_bundle_info, RendererInterface $renderer, $devel_dumper = NULL, $devel_generate_integration = NULL) {
     $this->formatterExtrasManager = $formatter_extras_manager;
     $this->fieldTypeManager = $field_type_manager;
     $this->fieldFormatterManager = $field_formatter_manager;
@@ -112,6 +121,7 @@ class FormatterForm extends EntityForm {
     $this->entityTypeBundleInfo = $entity_type_bundle_info;
     $this->renderer = $renderer;
     $this->develDumper = $devel_dumper;
+    $this->develGenerateIntegration = $devel_generate_integration;
   }
 
   /**
@@ -122,6 +132,7 @@ class FormatterForm extends EntityForm {
     // installed, the service won't exist and NULL is returned instead.
     // This avoids hard-coding a dependency on an optional module.
     $devel_dumper = $container->get('devel.dumper', ContainerInterface::NULL_ON_INVALID_REFERENCE);
+    $devel_generate_integration = $container->get('custom_formatters.devel_generate_integration');
     return new static(
       $container->get('plugin.manager.custom_formatters.formatter_extras'),
       $container->get('plugin.manager.field.formatter'),
@@ -129,7 +140,8 @@ class FormatterForm extends EntityForm {
       $container->get('entity_field.manager'),
       $container->get('entity_type.bundle.info'),
       $container->get('renderer'),
-      $devel_dumper
+      $devel_dumper,
+      $devel_generate_integration
     );
   }
 
@@ -291,11 +303,23 @@ class FormatterForm extends EntityForm {
     }
 
     $entity_options = ($entity_type_id && $bundle && $field_name) ? $this->getPreviewEntities($entity_type_id, $bundle, $field_name) : [];
-    if ($entity_id !== NULL && !isset($entity_options[$entity_id])) {
-      $entity_id = key($entity_options) ?: NULL;
+
+    $devel_generate = $this->develGenerateIntegration
+      && $this->develGenerateIntegration->isAvailable()
+      && !empty($entity_type_id)
+      && !empty($bundle)
+      && !empty($field_name)
+      && $this->develGenerateIntegration->isEntityTypeSupported($entity_type_id);
+
+    if ($devel_generate) {
+      $entity_options = ['devel_generate' => $this->t('Devel generate')] + $entity_options;
     }
 
     $preview_disabled = empty($entity_options);
+
+    if ($entity_id !== NULL && !isset($entity_options[$entity_id])) {
+      $entity_id = $devel_generate ? 'devel_generate' : (key($entity_options) ?: NULL);
+    }
 
     // Build the selects container with a flexbox-friendly class. The CSS
     // targets .preview-selects to arrange selects and the preview button
@@ -469,7 +493,10 @@ class FormatterForm extends EntityForm {
     $field_name = (string) key($fields);
 
     $entities = $field_name ? $this->getPreviewEntities($entity_type_id, $bundle, $field_name) : [];
-    $entity_id = key($entities);
+    $devel_generate = $this->develGenerateIntegration
+      && $this->develGenerateIntegration->isAvailable()
+      && $this->develGenerateIntegration->isEntityTypeSupported($entity_type_id);
+    $entity_id = $devel_generate && $field_name ? 'devel_generate' : key($entities);
 
     return [
       'entity_type' => $entity_type_id,
@@ -536,15 +563,39 @@ class FormatterForm extends EntityForm {
       return;
     }
 
-    $entity = $this->entityTypeManager->getStorage($entity_type_id)->load($entity_id);
-    if (!$entity instanceof FieldableEntityInterface || !$entity->access('view')) {
-      $form_state->set('preview_output', [
-        '#theme'        => 'status_messages',
-        '#message_list' => [
-          'error' => [$this->t('Unable to load the selected entity.')],
-        ],
-      ]);
-      return;
+    if ($entity_id === 'devel_generate') {
+      if (!$this->develGenerateIntegration || !$this->develGenerateIntegration->isAvailable()) {
+        $form_state->set('preview_output', [
+          '#theme'        => 'status_messages',
+          '#message_list' => [
+            'error' => [$this->t('Devel Generate is not available.')],
+          ],
+        ]);
+        return;
+      }
+
+      $entity = $this->develGenerateIntegration->generateEntity($entity_type_id, $bundle);
+      if (!$entity instanceof FieldableEntityInterface) {
+        $form_state->set('preview_output', [
+          '#theme'        => 'status_messages',
+          '#message_list' => [
+            'error' => [$this->t('Unable to generate sample entity via Devel Generate.')],
+          ],
+        ]);
+        return;
+      }
+    }
+    else {
+      $entity = $this->entityTypeManager->getStorage($entity_type_id)->load($entity_id);
+      if (!$entity instanceof FieldableEntityInterface || !$entity->access('view')) {
+        $form_state->set('preview_output', [
+          '#theme'        => 'status_messages',
+          '#message_list' => [
+            'error' => [$this->t('Unable to load the selected entity.')],
+          ],
+        ]);
+        return;
+      }
     }
 
     if (!$entity->hasField($field_name)) {
@@ -798,25 +849,27 @@ class FormatterForm extends EntityForm {
     $storage = $this->entityTypeManager->getStorage($entity_type_id);
 
     $query = $storage->getQuery()
-      ->accessCheck(TRUE)
-      ->range(0, 50);
+      ->accessCheck(TRUE);
 
     if ($bundle_key = $entity_type->getKey('bundle')) {
       $query->condition($bundle_key, $bundle);
     }
 
-    // Filter to entities with non-empty field data.
     $query->exists($field_name);
 
-    $ids = $query->execute();
+    $ids = array_keys($query->execute());
     if (empty($ids)) {
       return $options;
     }
 
+    shuffle($ids);
+    $ids = array_slice($ids, 0, 50);
+
     $entities = $storage->loadMultiple($ids);
     foreach ($entities as $id => $entity) {
       if ($entity->access('view')) {
-        $options[$id] = $entity->label() ?: (string) $id;
+        $label = $entity->label() ?: (string) $id;
+        $options[$id] = $label . " [eid:{$id}]";
       }
     }
 

--- a/src/Form/FormatterForm.php
+++ b/src/Form/FormatterForm.php
@@ -857,7 +857,7 @@ class FormatterForm extends EntityForm {
 
     $query->exists($field_name);
 
-    $ids = array_keys($query->execute());
+    $ids = array_keys($query->range(0, 500)->execute());
     if (empty($ids)) {
       return $options;
     }

--- a/src/Plugin/CustomFormatters/FormatterType/FormatterPreset.php
+++ b/src/Plugin/CustomFormatters/FormatterType/FormatterPreset.php
@@ -187,8 +187,9 @@ class FormatterPreset extends FormatterTypeBase {
   public function viewElements(FieldItemListInterface $items, $langcode): array {
     $data = $this->entity->get('data');
     $field_types = $this->entity->get('field_types');
-    return $this->getFormatter($data['formatter'], $field_types[0])
-      ->viewElements($items, $langcode);
+    $formatter = $this->getFormatter($data['formatter'], $field_types[0]);
+    $formatter->prepareView([$items]);
+    return $formatter->viewElements($items, $langcode);
   }
 
   /**

--- a/tests/src/Kernel/DevelGenerateIntegrationTest.php
+++ b/tests/src/Kernel/DevelGenerateIntegrationTest.php
@@ -184,16 +184,10 @@ class DevelGenerateIntegrationTest extends KernelTestBase {
    */
   public function testGenerateEntityExceptionReturnsNull(): void {
     $this->enableModules(['devel_generate']);
+    $service = $this->container->get('custom_formatters.devel_generate_integration');
 
-    $mock = $this->createMock(DevelGenerateIntegration::class);
-    $mock->method('isAvailable')->willReturn(TRUE);
-    $mock->method('isEntityTypeSupported')->willReturn(TRUE);
-    $mock->method('generateEntity')->willThrowException(new \Exception('Test exception'));
-
-    // The real service catches exceptions internally; verify the mock
-    // setup is correct for the FormatterForm tests.
-    $this->expectException(\Exception::class);
-    $mock->generateEntity('node', 'article');
+    $entity = $service->generateEntity('media', 'image');
+    $this->assertNull($entity);
   }
 
   /**

--- a/tests/src/Kernel/DevelGenerateIntegrationTest.php
+++ b/tests/src/Kernel/DevelGenerateIntegrationTest.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @file
+ * Kernel tests for the DevelGenerateIntegration service.
+ */
+
+namespace Drupal\Tests\custom_formatters\Kernel;
+
+use Drupal\custom_formatters\DevelGenerateIntegration;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\node\NodeTypeInterface;
+
+/**
+ * Tests the DevelGenerateIntegration service.
+ *
+ * @group custom_formatters
+ */
+class DevelGenerateIntegrationTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'custom_formatters',
+    'field',
+    'filter',
+    'node',
+    'system',
+    'text',
+    'user',
+  ];
+
+  /**
+   * The service under test.
+   */
+  protected DevelGenerateIntegration $service;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installConfig(['custom_formatters', 'filter', 'node']);
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('user');
+    $this->installSchema('node', 'node_access');
+    node_access_rebuild();
+
+    $node_type = $this->container->get('entity_type.manager')
+      ->getStorage('node_type')
+      ->create([
+        'type' => 'article',
+        'name' => 'Article',
+      ]);
+    assert($node_type instanceof NodeTypeInterface);
+
+    if (!FieldStorageConfig::loadByName('node', 'body')) {
+      FieldStorageConfig::create([
+        'field_name' => 'body',
+        'entity_type' => 'node',
+        'type' => 'text_with_summary',
+        'settings' => [],
+        'cardinality' => 1,
+      ])->save();
+    }
+
+    $node_type->save();
+
+    if (!FieldConfig::loadByName('node', 'article', 'body')) {
+      FieldConfig::create([
+        'field_name' => 'body',
+        'entity_type' => 'node',
+        'bundle' => 'article',
+        'label' => 'Body',
+      ])->save();
+    }
+
+    $this->service = $this->container->get('custom_formatters.devel_generate_integration');
+  }
+
+  /**
+   * Tests isAvailable() returns FALSE when devel_generate is not enabled.
+   */
+  public function testIsAvailableFalseWithoutModule(): void {
+    $this->assertFalse($this->service->isAvailable());
+  }
+
+  /**
+   * Tests isAvailable() returns TRUE when devel_generate is enabled.
+   */
+  public function testIsAvailableTrueWithModule(): void {
+    $this->enableModules(['devel_generate']);
+    $service = $this->container->get('custom_formatters.devel_generate_integration');
+    $this->assertTrue($service->isAvailable());
+  }
+
+  /**
+   * Tests isEntityTypeSupported() for supported and unsupported types.
+   */
+  public function testIsEntityTypeSupported(): void {
+    $this->assertTrue($this->service->isEntityTypeSupported('node'));
+    $this->assertTrue($this->service->isEntityTypeSupported('taxonomy_term'));
+    $this->assertTrue($this->service->isEntityTypeSupported('user'));
+    $this->assertTrue($this->service->isEntityTypeSupported('media'));
+    $this->assertFalse($this->service->isEntityTypeSupported('block_content'));
+    $this->assertFalse($this->service->isEntityTypeSupported('paragraph'));
+    $this->assertFalse($this->service->isEntityTypeSupported('comment'));
+  }
+
+  /**
+   * Tests generateEntity() returns NULL when Devel Generate is unavailable.
+   */
+  public function testGenerateEntityReturnsNullWhenUnavailable(): void {
+    $this->assertNull($this->service->generateEntity('node', 'article'));
+  }
+
+  /**
+   * Tests generateEntity() returns NULL for unsupported entity types.
+   */
+  public function testGenerateEntityReturnsNullWhenUnsupportedType(): void {
+    $this->enableModules(['devel_generate']);
+    $service = $this->container->get('custom_formatters.devel_generate_integration');
+    $this->assertNull($service->generateEntity('block_content', 'basic'));
+  }
+
+  /**
+   * Tests generateEntity() creates a node with correct default values.
+   */
+  public function testGenerateEntityNode(): void {
+    $this->enableModules(['devel_generate']);
+    $service = $this->container->get('custom_formatters.devel_generate_integration');
+
+    $entity = $service->generateEntity('node', 'article');
+    $this->assertNotNull($entity);
+    $this->assertEquals('node', $entity->getEntityTypeId());
+    $this->assertEquals('article', $entity->bundle());
+    $this->assertEquals('Sample Article', $entity->label());
+    $this->assertEquals(1, $entity->get('status')->value);
+  }
+
+  /**
+   * Tests generated entities are transient and never saved to the database.
+   */
+  public function testGenerateEntityIsTransient(): void {
+    $this->enableModules(['devel_generate']);
+    $service = $this->container->get('custom_formatters.devel_generate_integration');
+
+    $entity = $service->generateEntity('node', 'article');
+    $this->assertNotNull($entity);
+    $this->assertTrue($entity->isNew());
+    $this->assertNull($entity->id());
+
+    $count = $this->container->get('entity_type.manager')
+      ->getStorage('node')
+      ->getQuery()
+      ->accessCheck(FALSE)
+      ->count()
+      ->execute();
+    $this->assertEquals(0, $count);
+  }
+
+  /**
+   * Tests generateEntity() creates a user with correct default values.
+   */
+  public function testGenerateEntityUser(): void {
+    $this->enableModules(['devel_generate']);
+    $service = $this->container->get('custom_formatters.devel_generate_integration');
+
+    $entity = $service->generateEntity('user', 'user');
+    $this->assertNotNull($entity);
+    $this->assertEquals('user', $entity->getEntityTypeId());
+    $this->assertEquals('sample_user', $entity->label());
+    $this->assertEquals('sample@example.com', $entity->getEmail());
+    $this->assertEquals(1, $entity->get('status')->value);
+  }
+
+  /**
+   * Tests generateEntity() catches exceptions and returns NULL.
+   */
+  public function testGenerateEntityExceptionReturnsNull(): void {
+    $this->enableModules(['devel_generate']);
+
+    $mock = $this->createMock(DevelGenerateIntegration::class);
+    $mock->method('isAvailable')->willReturn(TRUE);
+    $mock->method('isEntityTypeSupported')->willReturn(TRUE);
+    $mock->method('generateEntity')->willThrowException(new \Exception('Test exception'));
+
+    // The real service catches exceptions internally; verify the mock
+    // setup is correct for the FormatterForm tests.
+    $this->expectException(\Exception::class);
+    $mock->generateEntity('node', 'article');
+  }
+
+  /**
+   * Tests getBundleLabel() returns the human-readable bundle label.
+   */
+  public function testGetBundleLabel(): void {
+    $ref = new \ReflectionClass($this->service);
+    $method = $ref->getMethod('getBundleLabel');
+    $method->setAccessible(TRUE);
+
+    $label = $method->invoke($this->service, 'node', 'article');
+    $this->assertEquals('Article', $label);
+  }
+
+  /**
+   * Tests getBundleLabel() falls back to the bundle ID for unknown bundles.
+   */
+  public function testGetBundleLabelFallback(): void {
+    $ref = new \ReflectionClass($this->service);
+    $method = $ref->getMethod('getBundleLabel');
+    $method->setAccessible(TRUE);
+
+    $label = $method->invoke($this->service, 'node', 'nonexistent');
+    $this->assertEquals('nonexistent', $label);
+  }
+
+}

--- a/tests/src/Kernel/FormatterPresetEntityReferenceTest.php
+++ b/tests/src/Kernel/FormatterPresetEntityReferenceTest.php
@@ -1,0 +1,267 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\custom_formatters\Kernel;
+
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\field\FieldConfigInterface;
+use Drupal\file\Entity\File;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+use Drupal\Tests\TestFileCreationTrait;
+
+/**
+ * Tests that formatter presets render entity reference-based fields.
+ *
+ * Regression test: FormatterPreset::viewElements() must call prepareView()
+ * before delegating to the core formatter. Without it, entity reference
+ * formatters (image, file, etc.) produce empty output because
+ * EntityReferenceFormatterBase::getEntitiesToView() skips items where
+ * _loaded is not set.
+ *
+ * @coversDefaultClass \Drupal\custom_formatters\Plugin\CustomFormatters\FormatterType\FormatterPreset
+ * @group custom_formatters
+ */
+class FormatterPresetEntityReferenceTest extends KernelTestBase {
+  use TestFileCreationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'custom_formatters',
+    'field',
+    'file',
+    'filter',
+    'image',
+    'node',
+    'system',
+    'text',
+    'user',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('file');
+    $this->installSchema('file', ['file_usage']);
+    $this->installSchema('system', ['sequences']);
+    $this->installConfig(['custom_formatters', 'filter', 'image']);
+  }
+
+  /**
+   * Tests that image fields render via formatter preset.
+   *
+   * ImageFormatter extends EntityReferenceFormatterBase which requires
+   * prepareView() to set _loaded on field items before getEntitiesToView()
+   * will return them.
+   *
+   * @covers ::viewElements
+   */
+  public function testImageFieldRendersViaFormatterPreset(): void {
+    NodeType::create(['type' => 'page', 'name' => 'Page'])->save();
+    FieldStorageConfig::create([
+      'field_name' => 'field_image',
+      'type' => 'image',
+      'entity_type' => 'node',
+    ])->save();
+    FieldConfig::create([
+      'field_name' => 'field_image',
+      'entity_type' => 'node',
+      'bundle' => 'page',
+      'label' => 'Image',
+    ])->save();
+
+    $images = $this->getTestFiles('image');
+    $image = reset($images);
+    $this->assertNotFalse($image);
+    $file = File::create([
+      'uri' => $image->uri ?? '',
+      'uid' => 1,
+      'status' => 1,
+    ]);
+    $file->save();
+
+    $node = Node::create([
+      'type' => 'page',
+      'title' => 'Test',
+      'uid' => 1,
+      'field_image' => [
+        'target_id' => $file->id(),
+        'alt' => 'Test alt',
+      ],
+    ]);
+    $node->save();
+
+    $formatter = \Drupal::entityTypeManager()
+      ->getStorage('formatter')
+      ->create([
+        'id' => 'image_preset_test',
+        'label' => 'Image Preset Test',
+        'type' => 'formatter_preset',
+        'field_types' => ['image'],
+        'data' => [
+          'formatter' => 'image',
+          'settings' => [
+            'image_style' => 'thumbnail',
+            'image_link' => '',
+          ],
+        ],
+      ]);
+    $formatter->save();
+
+    $formatter_type = $formatter->getFormatterType();
+    $this->assertNotFalse($formatter_type);
+
+    $items = $node->get('field_image');
+    $result = $formatter_type->viewElements($items, 'en');
+
+    $this->assertNotEmpty($result, 'Formatter preset produced output for image field.');
+    $rendered = '';
+    foreach ($result as $element) {
+      $rendered .= (string) \Drupal::service('renderer')->renderInIsolation($element);
+    }
+    $this->assertStringContainsString('<img', $rendered);
+    $this->assertStringContainsString('thumbnail', $rendered);
+  }
+
+  /**
+   * Tests that text fields render via formatter preset (non-entity-reference).
+   *
+   * Ensures the prepareView() addition does not break simple field types.
+   *
+   * @covers ::viewElements
+   */
+  public function testTextFieldRendersViaFormatterPreset(): void {
+    NodeType::create(['type' => 'page', 'name' => 'Page'])->save();
+    FieldStorageConfig::create([
+      'field_name' => 'body',
+      'type' => 'text_with_summary',
+      'entity_type' => 'node',
+    ])->save();
+    FieldConfig::create([
+      'field_name' => 'body',
+      'entity_type' => 'node',
+      'bundle' => 'page',
+      'label' => 'Body',
+    ])->save();
+
+    $node = Node::create([
+      'type' => 'page',
+      'title' => 'Test',
+      'uid' => 1,
+      'body' => [
+        'value' => '<p>Hello world</p>',
+        'format' => 'plain_text',
+      ],
+    ]);
+    $node->save();
+
+    $formatter = \Drupal::entityTypeManager()
+      ->getStorage('formatter')
+      ->create([
+        'id' => 'text_preset_test',
+        'label' => 'Text Preset Test',
+        'type' => 'formatter_preset',
+        'field_types' => ['text_with_summary'],
+        'data' => [
+          'formatter' => 'text_default',
+          'settings' => [],
+        ],
+      ]);
+    $formatter->save();
+
+    $formatter_type = $formatter->getFormatterType();
+    $this->assertNotFalse($formatter_type);
+
+    $items = $node->get('body');
+    $result = $formatter_type->viewElements($items, 'en');
+
+    $this->assertNotEmpty($result, 'Formatter preset produced output for text field.');
+    $rendered = '';
+    foreach ($result as $element) {
+      $rendered .= (string) \Drupal::service('renderer')->renderInIsolation($element);
+    }
+    $this->assertStringContainsString('Hello world', $rendered);
+  }
+
+  /**
+   * Tests that formatter preset renders with unsaved entity (Devel Generate).
+   *
+   * Simulates the Devel Generate preview scenario where the entity exists only
+   * in memory. The file is saved (by generateSampleItems) but the parent node
+   * is not.
+   *
+   * @covers ::viewElements
+   */
+  public function testImageFieldRendersWithUnsavedEntity(): void {
+    NodeType::create(['type' => 'page', 'name' => 'Page'])->save();
+    FieldStorageConfig::create([
+      'field_name' => 'field_image',
+      'type' => 'image',
+      'entity_type' => 'node',
+    ])->save();
+    FieldConfig::create([
+      'field_name' => 'field_image',
+      'entity_type' => 'node',
+      'bundle' => 'page',
+      'label' => 'Image',
+    ])->save();
+
+    $entity = Node::create([
+      'type' => 'page',
+      'title' => 'Unsaved',
+      'uid' => 1,
+    ]);
+    foreach ($entity->getFieldDefinitions() as $field_name => $definition) {
+      if ($definition instanceof FieldConfigInterface && $entity->hasField($field_name)) {
+        $field = $entity->get($field_name);
+        if ($field->isEmpty()) {
+          try {
+            $field->generateSampleItems();
+          }
+          catch (\Exception) {
+          }
+        }
+      }
+    }
+
+    $this->assertFalse($entity->get('field_image')->isEmpty(), 'Sample image was generated.');
+
+    $formatter = \Drupal::entityTypeManager()
+      ->getStorage('formatter')
+      ->create([
+        'id' => 'unsaved_image_test',
+        'label' => 'Unsaved Image Test',
+        'type' => 'formatter_preset',
+        'field_types' => ['image'],
+        'data' => [
+          'formatter' => 'image',
+          'settings' => [
+            'image_style' => '',
+            'image_link' => '',
+          ],
+        ],
+      ]);
+    $formatter->save();
+
+    $formatter_type = $formatter->getFormatterType();
+    $items = $entity->get('field_image');
+    $result = $formatter_type->viewElements($items, 'en');
+
+    $this->assertNotEmpty($result, 'Formatter preset produced output for unsaved entity.');
+    $rendered = '';
+    foreach ($result as $element) {
+      $rendered .= (string) \Drupal::service('renderer')->renderInIsolation($element);
+    }
+    $this->assertStringContainsString('<img', $rendered);
+  }
+
+}

--- a/tests/src/Kernel/FormatterPreviewFormTest.php
+++ b/tests/src/Kernel/FormatterPreviewFormTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\custom_formatters\Kernel;
 
+use Drupal\custom_formatters\DevelGenerateIntegration;
 use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormState;
@@ -576,6 +577,193 @@ class FormatterPreviewFormTest extends KernelTestBase {
     $output = $form_state->get('preview_output');
     $this->assertNotNull($output);
     $this->assertEquals('status_messages', $output['#theme']);
+  }
+
+  /**
+   * Tests "Devel generate" option is absent when devel_generate is disabled.
+   */
+  public function testDevelGenerateOptionAbsentWithoutModule(): void {
+    $formatter = $this->createFormatter('test_dg_absent');
+    $formatter->set('field_types', ['text', 'text_with_summary']);
+    $form = $this->buildForm($formatter);
+
+    $entity_select = $form['preview']['selects']['entity'];
+    $this->assertArrayNotHasKey('devel_generate', $entity_select['#options']);
+  }
+
+  /**
+   * Tests "Devel generate" option appears when devel_generate is enabled.
+   */
+  public function testDevelGenerateOptionAppearsWhenAvailable(): void {
+    $this->enableModules(['devel_generate']);
+
+    $formatter = $this->createFormatter('test_dg_present');
+    $formatter->set('field_types', ['text', 'text_with_summary']);
+    $form = $this->buildForm($formatter);
+
+    $entity_select = $form['preview']['selects']['entity'];
+    $this->assertArrayHasKey('devel_generate', $entity_select['#options']);
+    $this->assertEquals('Devel generate', $entity_select['#options']['devel_generate']);
+
+    $options = (array) $entity_select['#options'];
+    $non_empty_keys = array_filter(array_keys($options), fn($k) => $k !== '');
+    $this->assertEquals('devel_generate', reset($non_empty_keys));
+  }
+
+  /**
+   * Tests "Devel generate" is the default selection when available.
+   */
+  public function testDevelGenerateIsDefaultSelection(): void {
+    $this->enableModules(['devel_generate']);
+
+    $formatter = $this->createFormatter('test_dg_default');
+    $formatter->set('field_types', ['text', 'text_with_summary']);
+    $form = $this->buildForm($formatter);
+
+    $entity_select = $form['preview']['selects']['entity'];
+    $this->assertEquals('devel_generate', $entity_select['#default_value']);
+  }
+
+  /**
+   * Tests getPreviewDefaults returns 'devel_generate' when available.
+   */
+  public function testGetPreviewDefaultsWithDevelGenerate(): void {
+    $this->enableModules(['devel_generate']);
+
+    $formatter = $this->createFormatter('test_dg_defaults');
+    $formatter->set('field_types', ['text', 'text_with_summary']);
+    $form_object = $this->getFormObject($formatter);
+
+    $ref = new \ReflectionClass($form_object);
+    $method = $ref->getMethod('getPreviewDefaults');
+    $method->setAccessible(TRUE);
+
+    $defaults = $method->invoke($form_object, new FormState());
+    $this->assertEquals('node', $defaults['entity_type']);
+    $this->assertEquals('article', $defaults['bundle']);
+    $this->assertEquals('body', $defaults['field']);
+    $this->assertEquals('devel_generate', $defaults['entity']);
+  }
+
+  /**
+   * Tests previewSubmit with devel_generate entity produces output.
+   */
+  public function testPreviewSubmitWithDevelGenerate(): void {
+    $this->enableModules(['filter', 'devel_generate']);
+    $this->installConfig(['filter']);
+
+    $formatter = $this->createFormatter('test_dg_submit');
+    $formatter->set('field_types', ['text', 'text_with_summary']);
+    $formatter->save();
+    $form_object = $this->getFormObject($formatter);
+    $this->container->get('form_builder')->getForm($form_object);
+
+    $form_state = new FormState();
+    $form_state->setValue(['preview', 'selects', 'entity_type'], 'node');
+    $form_state->setValue(['preview', 'selects', 'bundle'], 'article');
+    $form_state->setValue(['preview', 'selects', 'field'], 'body');
+    $form_state->setValue(['preview', 'selects', 'entity'], 'devel_generate');
+
+    $form_object->previewSubmit([], $form_state);
+
+    $output = $form_state->get('preview_output');
+    $this->assertNotNull($output);
+    $this->assertArrayNotHasKey('#theme', $output);
+
+    $node_count = $this->container->get('entity_type.manager')
+      ->getStorage('node')
+      ->getQuery()
+      ->accessCheck(FALSE)
+      ->count()
+      ->execute();
+    $this->assertEquals(0, $node_count);
+  }
+
+  /**
+   * Tests previewSubmit shows error when Devel Generate is unavailable.
+   */
+  public function testPreviewSubmitDevelGenerateNotAvailable(): void {
+    $formatter = $this->createFormatter('test_dg_unavailable');
+    $formatter->set('field_types', ['text', 'text_with_summary']);
+    $formatter->save();
+    $form_object = $this->getFormObject($formatter);
+    $this->container->get('form_builder')->getForm($form_object);
+
+    $form_state = new FormState();
+    $form_state->setValue(['preview', 'selects', 'entity_type'], 'node');
+    $form_state->setValue(['preview', 'selects', 'bundle'], 'article');
+    $form_state->setValue(['preview', 'selects', 'field'], 'body');
+    $form_state->setValue(['preview', 'selects', 'entity'], 'devel_generate');
+
+    $form_object->previewSubmit([], $form_state);
+
+    $output = $form_state->get('preview_output');
+    $this->assertNotNull($output);
+    $this->assertEquals('status_messages', $output['#theme']);
+    $this->assertEquals('Devel Generate is not available.', (string) $output['#message_list']['error'][0]);
+  }
+
+  /**
+   * Tests previewSubmit shows error when entity generation fails.
+   */
+  public function testPreviewSubmitDevelGenerateGenerationFails(): void {
+    $this->enableModules(['devel_generate']);
+
+    $mock = $this->createMock(DevelGenerateIntegration::class);
+    $mock->method('isAvailable')->willReturn(TRUE);
+    $mock->method('isEntityTypeSupported')->willReturn(TRUE);
+    $mock->method('generateEntity')->willReturn(NULL);
+    $this->container->set('custom_formatters.devel_generate_integration', $mock);
+
+    $formatter = $this->createFormatter('test_dg_gen_fail');
+    $formatter->set('field_types', ['text', 'text_with_summary']);
+    $formatter->save();
+    $form_object = $this->getFormObject($formatter);
+    $this->container->get('form_builder')->getForm($form_object);
+
+    $form_state = new FormState();
+    $form_state->setValue(['preview', 'selects', 'entity_type'], 'node');
+    $form_state->setValue(['preview', 'selects', 'bundle'], 'article');
+    $form_state->setValue(['preview', 'selects', 'field'], 'body');
+    $form_state->setValue(['preview', 'selects', 'entity'], 'devel_generate');
+
+    $form_object->previewSubmit([], $form_state);
+
+    $output = $form_state->get('preview_output');
+    $this->assertNotNull($output);
+    $this->assertEquals('status_messages', $output['#theme']);
+    $this->assertStringContainsString('Unable to generate', (string) $output['#message_list']['error'][0]);
+  }
+
+  /**
+   * Tests getPreviewEntities label format includes entity ID.
+   */
+  public function testGetPreviewEntitiesLabelFormat(): void {
+    $user = $this->createUser(['bypass node access']);
+    assert($user instanceof AccountInterface);
+    $this->container->get('current_user')->setAccount($user);
+
+    $node = $this->container->get('entity_type.manager')
+      ->getStorage('node')
+      ->create([
+        'type' => 'article',
+        'title' => 'Test label format',
+        'body' => 'Some body text',
+      ]);
+    assert($node instanceof NodeInterface);
+    $node->save();
+
+    $formatter = $this->createFormatter('test_entity_labels');
+    $form_object = $this->getFormObject($formatter);
+
+    $ref = new \ReflectionClass($form_object);
+    $method = $ref->getMethod('getPreviewEntities');
+    $method->setAccessible(TRUE);
+
+    $entities = $method->invoke($form_object, 'node', 'article', 'body');
+    $this->assertNotEmpty($entities);
+    $this->assertArrayHasKey($node->id(), $entities);
+    $this->assertEquals("Test label format [eid:{$node->id()}]", $entities[$node->id()]);
   }
 
   /**


### PR DESCRIPTION
Integrates Devel Generate with the formatter preview form, allowing users to generate sample entities on-the-fly for live preview when no real entities exist with the target field type.
## Changes
### Devel Generate service (`src/DevelGenerateIntegration.php`)
- Detects whether `devel_generate` module is available
- Supports generating entities for supported entity types
- Generates ephemeral entities (not saved to database) for preview
### Preview form integration
- Adds "Devel generate" option to the entity select dropdown when available
- Sets it as the default selection when available (falls back to first real entity otherwise)
- Generates entity on preview submit and renders through the formatter
- Shows error messages when Devel Generate is unavailable or generation fails
### Tests
- **`tests/src/Kernel/DevelGenerateIntegrationTest.php`** — Unit-level tests for the `DevelGenerateIntegration` service
- **`tests/src/Kernel/FormatterPreviewFormTest.php`** — 7 new kernel tests covering:
  - Option absent when module disabled
  - Option appears and is default when enabled
  - Preview output from generated entity
  - Error when unavailable or generation fails
  - Entity label format includes ID
## Testing
```bash
DRUPAL_VERSION=10 make test-kernel --filter "CustomFormatters"
All 10 kernel tests pass (111 assertions).
```