### PR TITLE
ci: add markdownlint to CI and Makefile, fix phpunit coverage config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Lint Markdown files
+        run: npx markdownlint-cli README.md
+
       - name: Cache Composer dependencies
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
@@ -219,7 +222,7 @@ jobs:
           name: ${{github.job}}-code-coverage-report-${{ matrix.name }}
           path: ./.logs/coverage/phpunit/.coverage-html
           include-hidden-files: true
-          if-no-files-found: error
+          if-no-files-found: warn
 
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,5 @@
+{
+  "default": true,
+  "MD007": { "indent": 2 },
+  "MD013": { "line_length": 120 }
+}

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,8 @@ provision:
 	./.devtools/provision
 
 lint:
+	$(call title,Running Markdownlint)
+	npx markdownlint-cli README.md
 	$(call title,Running PHPCS)
 	pushd "build" >/dev/null || exit 1 && vendor/bin/phpcs && popd >/dev/null || exit 1
 	$(call title,Running PHPStan)

--- a/README.md
+++ b/README.md
@@ -1,67 +1,55 @@
 Custom Formatters
 =================
 
+[![Test](https://github.com/Decipher/custom_formatters/actions/workflows/test.yml/badge.svg?branch=4.1.x)](https://github.com/Decipher/custom_formatters/actions/workflows/test.yml?query=branch%3A4.1.x)
+[![Coverage](https://codecov.io/gh/Decipher/custom_formatters/branch/4.1.x/graph/badge.svg)](https://codecov.io/gh/Decipher/custom_formatters/branch/4.1.x)
+
 The Custom Formatters module allows users to easily create custom Field
 Formatters through an admin UI without writing a custom module. Custom Formatters
 are exported as Drupal configuration entities.
-
-
 
 Features
 --------
 
 * Pluggable formatter engines:
-    * **Formatter Preset**
-      Build formatters from existing field formatters with preset settings.
-
-    * **HTML + Tokens**
-      A HTML based editor with Token support, including a Token tree browser
-      when the Token module is installed.
-
-    * **PHP**
-      A PHP based editor with support for multiple fields and multiple values.
-
-    * **Twig**
-      A Twig based editor with support for multiple fields and multiple values.
-
+  * **Formatter Preset**
+    Build formatters from existing field formatters with preset settings.
+  * **HTML + Tokens**
+    A HTML based editor with Token support, including a Token tree browser
+    when the Token module is installed.
+  * **PHP**
+    A PHP based editor with support for multiple fields and multiple values.
+  * **Twig**
+    A Twig based editor with support for multiple fields and multiple values.
 * Supports all fieldable entities, including but not limited to:
-    * Drupal core — Comment, Node, Taxonomy term, User, and Media entities.
-
+  * Drupal core — Comment, Node, Taxonomy term, User, and Media entities.
 * Exportable as Drupal configuration entities.
-
 * Integrates with:
-    * **Contextual links** _(Drupal core)_
-      Adds a hover link for quick editing of Custom Formatters.
-
-    * **Token**
-      Adds the Token tree browser to the HTML + Tokens engine with automatic
-      entity reference token support.
-
-
+  * **Contextual links** _(Drupal core)_
+    Adds a hover link for quick editing of Custom Formatters.
+  * **Token**
+    Adds the Token tree browser to the HTML + Tokens engine with automatic
+    entity reference token support.
 
 Recommended Modules
 -------------------
 
 * [Token](https://www.drupal.org/project/token)
 * [Field tokens](https://www.drupal.org/project/field_tokens)
-* [CodeMirror Editor](https://www.drupal.org/project/codemirror_editor) — Provides syntax-highlighted code editing for the PHP, HTML+Token, and Twig formatter engines.
-
-
+* [CodeMirror Editor](https://www.drupal.org/project/codemirror_editor) —
+  Provides syntax-highlighted code editing for the PHP, HTML+Token, and Twig
+  formatter engines.
 
 Usage/Configuration
 -------------------
 
 Read the manual at: [drupal.org/node/2514412](https://www.drupal.org/node/2514412)
 
-
-
 Requirements
 ------------
 
 * Drupal 10 or 11
 * PHP 8.2+
-
-
 
 Testing
 -------
@@ -76,19 +64,18 @@ based development environment.
 
 See `AGENTS.md` in the module root for the full list of available commands.
 
-
-
 TODOs / Roadmap
 ---------------
 
 * Add Contextual links configuration as formatter setting.
 * Add granular permissions to Formatter types.
 * Add Formatter list view?
-  - Would require adding support for Formatter config entities in Views.
+  * Would require adding support for Formatter config entities in Views.
 * Add custom support for admin theme / Formatter add page.
 * Add ability to change field types that aren't in use.
 * Set usages of formatters to default formatter on deletion.
 * ~~Re-add save & edit?~~ (Added in 4.1.x)
 * Re-add preview.
-* ~~Replace EditArea with a modern code editor.~~ (Added in 4.1.x, via [CodeMirror Editor](https://www.drupal.org/project/codemirror_editor))
+* ~~Replace EditArea with a modern code editor.~~ (Added in 4.1.x, via
+  [CodeMirror Editor](https://www.drupal.org/project/codemirror_editor))
 * Re-add export?

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+codecov:
+  branch: 4.1.x
+
+coverage:
+  status:
+    patch: off
+
+fix:
+  - "web/modules/custom/custom_formatters/::"

--- a/phpunit.d10.xml
+++ b/phpunit.d10.xml
@@ -104,7 +104,6 @@
             <directory>web/modules/custom/*/tests</directory>
             <directory>web/themes/custom/*/tests</directory>
             <file>web/modules/custom/custom_formatters/rector.php</file>
-            <file>web/themes/custom/custom_formatters/rector.php</file>
             <directory>**/node_modules/**</directory>
         </exclude>
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -121,7 +121,6 @@
             <directory>web/modules/custom/*/tests</directory>
             <directory>web/themes/custom/*/tests</directory>
             <file>web/modules/custom/custom_formatters/rector.php</file>
-            <file>web/themes/custom/custom_formatters/rector.php</file>
             <directory>**/node_modules/**</directory>
         </exclude>
     </source>


### PR DESCRIPTION
- Add markdownlint-cli step to GitHub Actions and Makefile lint target
- Change coverage artifact if-no-files-found from error to warn
- Remove stale theme rector.php exclude from phpunit configs