### PR TITLE
feat: add Insert module integration for image and file fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 4.1.x-dev
+
+### Features
+
+- Added [Insert](https://www.drupal.org/project/insert) module integration —
+  custom formatters targeting `image`, `file`, or `entity_reference` fields
+  are automatically exposed as Insert styles, allowing formatted output to be
+  inserted directly into WYSIWYG editors.
+
 ## 4.1.0-beta3 (2026-06-07)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@ Read the manual at:
   - **Devel Generate** _(optional)_ — Generates sample entities with dummy
     field data for the live preview system when no real entities exist with
     the target field type.
+  - **Insert** _(optional)_ — Exposes custom formatters as
+    [Insert](https://www.drupal.org/project/insert) styles for `image`,
+    `file`, and `entity_reference` fields, allowing formatted output to be
+    inserted directly into WYSIWYG editors. Activate by installing the Insert
+    module alongside Custom Formatters; no additional configuration required.
 
 ## Roadmap
 
@@ -108,8 +113,6 @@ Planned features for future releases:
   against Drupal coding standards directly in the formatter edit form.
 - **Display Suite integration** — Format Display Suite fields with custom
   formatters.
-- **Insert integration** — Expose custom formatters as Insert styles for
-  image and file fields.
 - **JSON:API integration** — Apply custom formatters to JSON:API field
   output.
 - **Field type management** — Change a formatter's field types after

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "drupal/codemirror_editor": "Provides syntax-highlighted code editing via CodeMirror for the PHP, HTML+Token, and Twig formatter engines.",
         "drupal/devel": "Provides debug output options for the preview feature and Devel Generate integration for generating sample preview content.",
         "drupal/field_tokens": "Provides field-level token support, useful for testing HTML+Token formatters.",
-        "drupal/insert": "Allows custom formatters targeting image/file fields to appear as Insert styles.",
+        "drupal/insert": "Allows custom formatters targeting image, file, and entity_reference fields to appear as Insert styles.",
         "drupal/token": "Provides token replacement support for the HTML Token formatter type."
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,14 @@
     },
     "require-dev": {
         "drupal/devel": "^5",
+        "drupal/insert": "^3",
         "drupal/token": "^1"
     },
     "suggest": {
         "drupal/codemirror_editor": "Provides syntax-highlighted code editing via CodeMirror for the PHP, HTML+Token, and Twig formatter engines.",
         "drupal/devel": "Provides debug output options for the preview feature and Devel Generate integration for generating sample preview content.",
         "drupal/field_tokens": "Provides field-level token support, useful for testing HTML+Token formatters.",
+        "drupal/insert": "Allows custom formatters targeting image/file fields to appear as Insert styles.",
         "drupal/token": "Provides token replacement support for the HTML Token formatter type."
     }
 }

--- a/modules/insert.inc
+++ b/modules/insert.inc
@@ -80,12 +80,16 @@ function custom_formatters_insert_render(string $style_name, array $vars, array 
 
   // Determine the field type based on what the formatter supports.
   $formatter_field_types = $formatter->get('field_types') ?? [];
-  $field_type = 'entity_reference';
+  $field_type = NULL;
   foreach (['image', 'file', 'entity_reference'] as $type) {
     if (in_array($type, $formatter_field_types, TRUE)) {
       $field_type = $type;
       break;
     }
+  }
+
+  if ($field_type === NULL) {
+    return '';
   }
 
   // Create a temporary field definition matching the formatter's field type.
@@ -119,24 +123,38 @@ function custom_formatters_insert_render(string $style_name, array $vars, array 
   }
   $items->appendItem($value);
 
-  // Instantiate the field formatter plugin.
-  $plugin_manager = \Drupal::service('plugin.manager.field.formatter');
-  $formatter_instance = $plugin_manager->createInstance(
-    'custom_formatters:' . $formatter_id,
-    [
-      'field_definition' => $field_definition,
-      'settings' => [],
-      'label' => 'hidden',
-      'view_mode' => '_custom',
-      'third_party_settings' => [],
-    ],
-  );
+  // Instantiate the field formatter plugin and render.
+  $ob_level = ob_get_level();
+  try {
+    $plugin_manager = \Drupal::service('plugin.manager.field.formatter');
+    $formatter_instance = $plugin_manager->createInstance(
+      'custom_formatters:' . $formatter_id,
+      [
+        'field_definition' => $field_definition,
+        'settings' => [],
+        'label' => 'hidden',
+        'view_mode' => '_custom',
+        'third_party_settings' => [],
+      ],
+    );
 
-  \assert($formatter_instance instanceof FormatterInterface);
-  $elements = $formatter_instance->viewElements($items, $items->getLangcode());
-  if (empty($elements)) {
+    \assert($formatter_instance instanceof FormatterInterface);
+    $elements = $formatter_instance->viewElements($items, $items->getLangcode());
+    if (empty($elements)) {
+      return '';
+    }
+
+    return (string) \Drupal::service('renderer')->renderInIsolation($elements);
+  }
+  catch (\Throwable $e) {
+    // Close any output buffers the formatter engine opened before throwing.
+    while (ob_get_level() > $ob_level) {
+      ob_end_clean();
+    }
+    \Drupal::logger('custom_formatters')->error(
+      'Insert render failed for formatter %id: @message',
+      ['%id' => $formatter_id, '@message' => $e->getMessage()],
+    );
     return '';
   }
-
-  return (string) \Drupal::service('renderer')->renderInIsolation($elements);
 }

--- a/modules/insert.inc
+++ b/modules/insert.inc
@@ -1,0 +1,142 @@
+<?php
+
+/**
+ * @file
+ * Insert module integration for Custom Formatters.
+ *
+ * Loaded automatically by hook_module_implements_alter() when the
+ * insert module is installed.
+ */
+
+declare(strict_types=1);
+
+use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\Field\FormatterInterface;
+use Drupal\custom_formatters\FormatterInterface as CustomFormattersFormatterInterface;
+use Drupal\custom_formatters\InsertFieldItemList;
+use Drupal\file\FileInterface;
+
+/**
+ * Implements hook_insert_styles().
+ */
+function custom_formatters_insert_styles(string $insert_type): array {
+  if (!\Drupal::moduleHandler()->moduleExists('insert')) {
+    return [];
+  }
+
+  if (!in_array($insert_type, ['image', 'file'], TRUE)) {
+    return [];
+  }
+
+  $compatible_field_types = $insert_type === 'image' ? ['image'] : ['file', 'entity_reference'];
+
+  $formatters = \Drupal::entityTypeManager()
+    ->getStorage('formatter')
+    ->loadByProperties(['status' => TRUE]);
+
+  $styles = [];
+  foreach ($formatters as $formatter) {
+    $formatter_field_types = $formatter->get('field_types') ?? [];
+    if (empty(array_intersect($compatible_field_types, $formatter_field_types))) {
+      continue;
+    }
+
+    $style_name = 'custom_formatters__' . $formatter->id();
+    $styles[$style_name] = [
+      'label' => $formatter->label(),
+      'weight' => 0,
+    ];
+  }
+
+  return $styles;
+}
+
+/**
+ * Implements hook_insert_render().
+ */
+function custom_formatters_insert_render(string $style_name, array $vars, array $insert_element): string {
+  if (!\Drupal::moduleHandler()->moduleExists('insert')) {
+    return '';
+  }
+
+  if (!str_starts_with($style_name, 'custom_formatters__')) {
+    return '';
+  }
+
+  $formatter_id = substr($style_name, strlen('custom_formatters__'));
+
+  $formatter = \Drupal::entityTypeManager()
+    ->getStorage('formatter')
+    ->load($formatter_id);
+
+  if (!$formatter instanceof CustomFormattersFormatterInterface || !$formatter->status()) {
+    return '';
+  }
+
+  $file = $vars['file'] ?? NULL;
+  if (!$file instanceof FileInterface) {
+    return '';
+  }
+
+  // Determine the field type based on what the formatter supports.
+  $formatter_field_types = $formatter->get('field_types') ?? [];
+  $field_type = 'entity_reference';
+  foreach (['image', 'file', 'entity_reference'] as $type) {
+    if (in_array($type, $formatter_field_types, TRUE)) {
+      $field_type = $type;
+      break;
+    }
+  }
+
+  // Create a temporary field definition matching the formatter's field type.
+  $field_definition = BaseFieldDefinition::create($field_type)
+    ->setName('_insert_file')
+    ->setTargetEntityTypeId('file');
+
+  // Suppress alt/title for image fields in this context.
+  if ($field_type === 'image') {
+    $field_definition->setSetting('alt_field', FALSE);
+    $field_definition->setSetting('title_field', FALSE);
+  }
+
+  // Create a field item list with the file entity reference.
+  $items = new InsertFieldItemList(
+    $field_definition,
+    '_insert_file',
+    $file,
+    \Drupal::languageManager()->getCurrentLanguage()->getId(),
+  );
+
+  // Build the field item value based on the resolved field type.
+  $value = ['target_id' => (int) $file->id()];
+  if ($field_type === 'image') {
+    $value['alt'] = '';
+    $value['title'] = $file->getFilename();
+  }
+  elseif ($field_type === 'file') {
+    $value['display'] = 1;
+    $value['description'] = '';
+  }
+  $items->appendItem($value);
+
+  // Instantiate the field formatter plugin.
+  $plugin_manager = \Drupal::service('plugin.manager.field.formatter');
+  $formatter_instance = $plugin_manager->createInstance(
+    'custom_formatters:' . $formatter_id,
+    [
+      'field_definition' => $field_definition,
+      'settings' => [],
+      'label' => 'hidden',
+      'view_mode' => '_custom',
+      'third_party_settings' => [],
+    ],
+  );
+
+  \assert($formatter_instance instanceof FormatterInterface);
+  $elements = $formatter_instance->viewElements($items, $items->getLangcode());
+  if (empty($elements)) {
+    return '';
+  }
+
+  return (string) \Drupal::service('renderer')->renderInIsolation($elements);
+}

--- a/src/InsertFieldItemList.php
+++ b/src/InsertFieldItemList.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\custom_formatters;
+
+use Drupal\Core\Field\EntityReferenceFieldItemList;
+use Drupal\Core\TypedData\DataDefinitionInterface;
+use Drupal\file\FileInterface;
+
+/**
+ * Field item list that wraps a file entity for Insert rendering.
+ *
+ * Extends EntityReferenceFieldItemList (rather than FieldItemList) so that
+ * formatters such as ImageFormatter that type-hint against
+ * EntityReferenceFieldItemListInterface receive the correct type.
+ *
+ * In Drupal 11, content entities no longer implement TypedDataInterface,
+ * so they cannot be passed as the $parent to FieldItemList. This subclass
+ * stores the file entity separately and returns it from getEntity().
+ */
+class InsertFieldItemList extends EntityReferenceFieldItemList {
+
+  /**
+   * The file entity rendered by this field item list.
+   *
+   * @var \Drupal\file\FileInterface
+   */
+  protected FileInterface $entity;
+
+  /**
+   * Constructs an InsertFieldItemList.
+   *
+   * @param \Drupal\Core\TypedData\DataDefinitionInterface $definition
+   *   The field definition.
+   * @param string $name
+   *   The field name.
+   * @param \Drupal\file\FileInterface $file
+   *   The file entity to render.
+   * @param string $langcode
+   *   The language code.
+   */
+  public function __construct(DataDefinitionInterface $definition, string $name, FileInterface $file, string $langcode) {
+    parent::__construct($definition, $name, NULL);
+    $this->entity = $file;
+    $this->langcode = $langcode;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getEntity() {
+    return $this->entity;
+  }
+
+}

--- a/tests/src/Functional/CustomFormattersTestBase.php
+++ b/tests/src/Functional/CustomFormattersTestBase.php
@@ -72,6 +72,7 @@ abstract class CustomFormattersTestBase extends BrowserTestBase {
       'administer content types',
       'administer custom formatters',
       'administer node display',
+      'administer node form display',
     ]);
 
     // Ensure relevant configuration present if profile isn't 'standard'.

--- a/tests/src/Functional/InsertIntegrationTest.php
+++ b/tests/src/Functional/InsertIntegrationTest.php
@@ -1,0 +1,342 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\custom_formatters\Functional;
+
+use Drupal\Core\Field\FormatterInterface;
+use Drupal\file\Entity\File;
+use Drupal\node\Entity\Node;
+use Drupal\Tests\TestFileCreationTrait;
+
+/**
+ * Tests Insert module integration for Custom Formatters.
+ *
+ * The Insert stub module (custom_formatters_test_insert) is enabled selectively
+ * per-test via $modules so that tests which check the moduleExists() guard run
+ * without it and tests that exercise the full code path run with it.
+ *
+ * @group custom_formatters
+ */
+class InsertIntegrationTest extends CustomFormattersTestBase {
+
+  use TestFileCreationTrait;
+
+  /**
+   * {@inheritDoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * Modules to enable.
+   *
+   * @var array<string>
+   */
+  protected static $modules = [
+    'block',
+    'custom_formatters_test',
+    'insert',
+    'field_ui',
+    'file',
+    'image',
+    'node',
+    'text',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    // Load the insert integration file so its functions are available
+    // for direct invocation in tests.
+    require_once \Drupal::root() . '/' . \Drupal::service('extension.list.module')
+      ->getPath('custom_formatters') . '/modules/insert.inc';
+  }
+
+  /**
+   * Test the style registration and field-type filtering logic.
+   *
+   * Verifies that custom_formatters_insert_styles() correctly:
+   * - Exposes image formatters for the 'image' insert type.
+   * - Exposes file and entity_reference formatters for the 'file' insert type.
+   * - Excludes non-matching field types.
+   * - Returns empty for unrecognized insert types.
+   */
+  public function testInsertStylesFiltering(): void {
+    $this->assertTrue(\Drupal::moduleHandler()->moduleExists('insert'), 'Insert stub module is active.');
+
+    $image_fmt = $this->createCustomFormatter([
+      'type' => 'php',
+      'field_types' => ['image'],
+      'data' => "return 'img';",
+    ]);
+
+    $file_fmt = $this->createCustomFormatter([
+      'type' => 'php',
+      'field_types' => ['file'],
+      'data' => "return 'file';",
+    ]);
+
+    $er_fmt = $this->createCustomFormatter([
+      'type' => 'php',
+      'field_types' => ['entity_reference'],
+      'data' => "return 'er';",
+    ]);
+
+    $text_fmt = $this->createCustomFormatter([
+      'type' => 'php',
+      'field_types' => ['text'],
+      'data' => "return 'txt';",
+    ]);
+
+    // 'image' insert type: only image formatters.
+    $image_styles = custom_formatters_insert_styles('image');
+    $this->assertArrayHasKey('custom_formatters__' . $image_fmt->id(), $image_styles, 'Image formatter appears for image insert type.');
+    $this->assertArrayNotHasKey('custom_formatters__' . $file_fmt->id(), $image_styles, 'File formatter excluded from image insert type.');
+    $this->assertArrayNotHasKey('custom_formatters__' . $er_fmt->id(), $image_styles, 'Entity reference formatter excluded from image insert type.');
+    $this->assertArrayNotHasKey('custom_formatters__' . $text_fmt->id(), $image_styles, 'Text formatter excluded from image insert type.');
+
+    // 'file' insert type: file and entity_reference formatters.
+    $file_styles = custom_formatters_insert_styles('file');
+    $this->assertArrayNotHasKey('custom_formatters__' . $image_fmt->id(), $file_styles, 'Image formatter excluded from file insert type.');
+    $this->assertArrayHasKey('custom_formatters__' . $file_fmt->id(), $file_styles, 'File formatter appears for file insert type.');
+    $this->assertArrayHasKey('custom_formatters__' . $er_fmt->id(), $file_styles, 'Entity reference formatter appears for file insert type.');
+    $this->assertArrayNotHasKey('custom_formatters__' . $text_fmt->id(), $file_styles, 'Text formatter excluded from file insert type.');
+
+    // Unrecognized insert type returns empty.
+    $this->assertEmpty(custom_formatters_insert_styles('video'), 'Unrecognized insert type returns empty.');
+  }
+
+  /**
+   * Test custom_formatters_insert_render() with an image formatter.
+   *
+   * Exercises the full code path including InsertFieldItemList.
+   */
+  public function testInsertRender(): void {
+    $this->assertTrue(\Drupal::moduleHandler()->moduleExists('insert'), 'Insert stub module is active.');
+
+    $formatter = $this->createCustomFormatter([
+      'type' => 'php',
+      'field_types' => ['image'],
+      'data' => "return 'RENDERED:' . \$items->first()->entity->getFilename();",
+    ]);
+
+    $images = $this->getTestFiles('image');
+    $image = reset($images);
+    $file = File::create([
+      'uri' => $image->uri ?? '',
+      'uid' => 1,
+      'status' => 1,
+    ]);
+    $file->save();
+
+    $style_name = 'custom_formatters__' . $formatter->id();
+
+    // Verify the formatter appears in Insert styles.
+    $styles = custom_formatters_insert_styles('image');
+    $this->assertArrayHasKey($style_name, $styles, 'Formatter appears as an Insert style.');
+
+    // Verify the full insert_render hook path, exercising InsertFieldItemList.
+    $rendered = custom_formatters_insert_render($style_name, ['file' => $file], []);
+    $this->assertNotEmpty($rendered, 'insert_render returned a non-empty string.');
+    $this->assertStringContainsString('RENDERED:', $rendered, 'Formatter output prefix is present.');
+    $this->assertStringContainsString($file->getFilename(), $rendered, 'Formatter output contains the filename.');
+
+    // Non-matching style name returns empty.
+    $this->assertSame('', custom_formatters_insert_render('other_module__style', ['file' => $file], []), 'Non-matching style returns empty string.');
+
+    // Missing file returns empty.
+    $this->assertSame('', custom_formatters_insert_render($style_name, [], []), 'Missing file returns empty string.');
+  }
+
+  /**
+   * Test rendering through a custom formatter using a node-based approach.
+   *
+   * Creates a node with an image field, attaches a file, and renders the
+   * field through a custom formatter — the same rendering path used by
+   * custom_formatters_insert_render().
+   */
+  public function testFormatterRenderingWithFileFieldItemList(): void {
+    // Create an image field on the article content type.
+    $field_storage = \Drupal::entityTypeManager()
+      ->getStorage('field_storage_config')
+      ->create([
+        'field_name' => 'field_render_test',
+        'type' => 'image',
+        'entity_type' => 'node',
+      ]);
+    $field_storage->save();
+
+    $field_config = \Drupal::entityTypeManager()
+      ->getStorage('field_config')
+      ->create([
+        'field_name' => 'field_render_test',
+        'entity_type' => 'node',
+        'bundle' => 'article',
+        'label' => 'Render Test',
+      ]);
+    $field_config->save();
+
+    // Create the test file.
+    $images = $this->getTestFiles('image');
+    $image = reset($images);
+    $file = File::create([
+      'uri' => $image->uri ?? '',
+      'uid' => 1,
+      'status' => 1,
+    ]);
+    $file->save();
+
+    // Create a node with the image field.
+    $node = Node::create([
+      'type' => 'article',
+      'title' => 'Insert Render Test',
+      'field_render_test' => [
+        'target_id' => $file->id(),
+        'alt' => '',
+        'title' => $file->getFilename(),
+      ],
+    ]);
+    $node->save();
+
+    // Create the custom formatter for image fields.
+    // Uses $items->first()->entity to access the referenced file entity.
+    $formatter = $this->createCustomFormatter([
+      'type' => 'php',
+      'field_types' => ['image'],
+      'data' => "return 'RENDERED:' . \$items->first()->entity->getFilename();",
+    ]);
+
+    // Get the FieldItemList from the node (properly constructed by the entity
+    // system with the correct TypedData parent chain).
+    $items = $node->get('field_render_test');
+
+    // Create the formatter plugin instance.
+    $plugin_manager = \Drupal::service('plugin.manager.field.formatter');
+    $formatter_instance = $plugin_manager->createInstance(
+      'custom_formatters:' . $formatter->id(),
+      [
+        'field_definition' => $field_config,
+        'settings' => [],
+        'label' => 'hidden',
+        'view_mode' => '_custom',
+        'third_party_settings' => [],
+      ],
+    );
+
+    \assert($formatter_instance instanceof FormatterInterface);
+    $elements = $formatter_instance->viewElements($items, $items->getLangcode());
+
+    $this->assertNotEmpty($elements, 'Rendering returned elements.');
+    $rendered = (string) \Drupal::service('renderer')->renderInIsolation($elements);
+    $this->assertStringContainsString('RENDERED:', $rendered, 'Formatter output contains expected prefix.');
+    $this->assertStringContainsString($file->getFilename(), $rendered, 'Formatter output contains the filename.');
+  }
+
+  /**
+   * Test rendering via entity_reference through a custom formatter.
+   */
+  public function testFormatterRenderingWithEntityReferenceFieldItemList(): void {
+    // Create an entity_reference field on the article content type.
+    $field_storage = \Drupal::entityTypeManager()
+      ->getStorage('field_storage_config')
+      ->create([
+        'field_name' => 'field_er_test',
+        'type' => 'entity_reference',
+        'entity_type' => 'node',
+        'settings' => ['target_type' => 'file'],
+      ]);
+    $field_storage->save();
+
+    $field_config = \Drupal::entityTypeManager()
+      ->getStorage('field_config')
+      ->create([
+        'field_name' => 'field_er_test',
+        'entity_type' => 'node',
+        'bundle' => 'article',
+        'label' => 'ER Test',
+        'settings' => ['handler' => 'default:file'],
+      ]);
+    $field_config->save();
+
+    // Create the test file.
+    $images = $this->getTestFiles('image');
+    $image = reset($images);
+    $file = File::create([
+      'uri' => $image->uri ?? '',
+      'uid' => 1,
+      'status' => 1,
+    ]);
+    $file->save();
+
+    // Create a node with the entity_reference field.
+    $node = Node::create([
+      'type' => 'article',
+      'title' => 'Insert ER Test',
+      'field_er_test' => ['target_id' => $file->id()],
+    ]);
+    $node->save();
+
+    // Create the custom formatter for entity_reference fields.
+    $formatter = $this->createCustomFormatter([
+      'type' => 'php',
+      'field_types' => ['entity_reference'],
+      'data' => "return 'ER-RENDERED:' . \$items->first()->entity->getFilename();",
+    ]);
+
+    // Get the FieldItemList from the node.
+    $items = $node->get('field_er_test');
+
+    // Create the formatter plugin instance.
+    $plugin_manager = \Drupal::service('plugin.manager.field.formatter');
+    $formatter_instance = $plugin_manager->createInstance(
+      'custom_formatters:' . $formatter->id(),
+      [
+        'field_definition' => $field_config,
+        'settings' => [],
+        'label' => 'hidden',
+        'view_mode' => '_custom',
+        'third_party_settings' => [],
+      ],
+    );
+
+    \assert($formatter_instance instanceof FormatterInterface);
+    $elements = $formatter_instance->viewElements($items, $items->getLangcode());
+
+    $this->assertNotEmpty($elements, 'Entity reference rendering returned elements.');
+    $rendered = (string) \Drupal::service('renderer')->renderInIsolation($elements);
+    $this->assertStringContainsString('ER-RENDERED:', $rendered, 'Entity reference formatter output contains expected prefix.');
+    $this->assertStringContainsString($file->getFilename(), $rendered, 'Formatter output contains the filename.');
+  }
+
+  /**
+   * Test that the manage form display page loads without errors.
+   */
+  public function testManageDisplayPage(): void {
+    // Create an image field on the article content type.
+    $field_storage = \Drupal::entityTypeManager()
+      ->getStorage('field_storage_config')
+      ->create([
+        'field_name' => 'field_display_test',
+        'type' => 'image',
+        'entity_type' => 'node',
+      ]);
+    $field_storage->save();
+
+    \Drupal::entityTypeManager()
+      ->getStorage('field_config')
+      ->create([
+        'field_name' => 'field_display_test',
+        'entity_type' => 'node',
+        'bundle' => 'article',
+        'label' => 'Display Test',
+      ])
+      ->save();
+
+    $this->drupalGet('admin/structure/types/manage/article/form-display');
+    $this->assertSession()->statusCodeEquals(200);
+  }
+
+}

--- a/tests/src/Functional/InsertIntegrationTest.php
+++ b/tests/src/Functional/InsertIntegrationTest.php
@@ -117,10 +117,11 @@ class InsertIntegrationTest extends CustomFormattersTestBase {
   public function testInsertRender(): void {
     $this->assertTrue(\Drupal::moduleHandler()->moduleExists('insert'), 'Insert stub module is active.');
 
+    // Use $items->getEntity() to exercise InsertFieldItemList::getEntity().
     $formatter = $this->createCustomFormatter([
       'type' => 'php',
       'field_types' => ['image'],
-      'data' => "return 'RENDERED:' . \$items->first()->entity->getFilename();",
+      'data' => "return 'RENDERED:' . \$items->getEntity()->getFilename();",
     ]);
 
     $images = $this->getTestFiles('image');
@@ -149,6 +150,25 @@ class InsertIntegrationTest extends CustomFormattersTestBase {
 
     // Missing file returns empty.
     $this->assertSame('', custom_formatters_insert_render($style_name, [], []), 'Missing file returns empty string.');
+
+    // Formatter targeting a non-Insert-compatible type returns empty
+    // (covers the $field_type === NULL early return).
+    $text_fmt = $this->createCustomFormatter([
+      'type' => 'php',
+      'field_types' => ['text'],
+      'data' => "return 'text';",
+    ]);
+    $text_style = 'custom_formatters__' . $text_fmt->id();
+    $this->assertSame('', custom_formatters_insert_render($text_style, ['file' => $file], []), 'Non-file formatter returns empty string.');
+
+    // Formatter whose PHP throws covers the catch(\Throwable) error path.
+    $broken_fmt = $this->createCustomFormatter([
+      'type' => 'php',
+      'field_types' => ['image'],
+      'data' => "throw new \\RuntimeException('insert render test error');",
+    ]);
+    $broken_style = 'custom_formatters__' . $broken_fmt->id();
+    $this->assertSame('', custom_formatters_insert_render($broken_style, ['file' => $file], []), 'Formatter exception returns empty string.');
   }
 
   /**


### PR DESCRIPTION
Restores Insert module integration from the Drupal 7 version of Custom
Formatters. When the [Insert](https://www.drupal.org/project/insert) module
is installed, custom formatters targeting `image`, `file`, or
`entity_reference` fields are automatically exposed as Insert styles,
allowing formatted output to be inserted directly into WYSIWYG editors.
The integration is purely opt-in — nothing changes when Insert is absent.

## Insert hooks

`hook_insert_styles()` loads all enabled formatters and filters by field
type: `image` formatters are exposed for the `image` insert type; `file` and
`entity_reference` formatters for the `file` insert type. Style keys are
prefixed `custom_formatters__<id>` to avoid collisions.

`hook_insert_render()` builds a temporary field item list from the file
entity passed by Insert, instantiates the matching field formatter plugin,
and returns rendered HTML via `renderInIsolation()`.

Both hooks are implemented in `modules/insert.inc`, which is loaded
automatically by the existing `hook_module_implements_alter()` mechanism
only when the Insert module is installed.

## InsertFieldItemList

A new `InsertFieldItemList` class is introduced to wrap the file entity for
rendering. It extends `EntityReferenceFieldItemList` (not `FieldItemList`)
for two reasons:

1. **Drupal 11 compatibility** — content entities no longer implement
   `TypedDataInterface`, so they cannot be passed as the `$parent` argument
   to `FieldItemList`. `InsertFieldItemList` stores the entity directly and
   returns it from `getEntity()`.
2. **Core formatter compatibility** — formatters such as `ImageFormatterBase`
   and the `FormatterPreset` engine type-hint against
   `EntityReferenceFieldItemListInterface`, which `FieldItemList` does not
   satisfy. Extending `EntityReferenceFieldItemList` provides this without
   any additional implementation.

## Changes

- `modules/insert.inc` — new: `hook_insert_styles()` and `hook_insert_render()`
- `src/InsertFieldItemList.php` — new: field item list wrapper for Insert rendering
- `tests/src/Functional/InsertIntegrationTest.php` — new: 5 functional tests
  covering style filtering, full render hook path, and node-based rendering
  for image and entity_reference fields
- `tests/src/Functional/CustomFormattersTestBase.php` — add `administer node
  form display` permission
- `composer.json` — add `drupal/insert: ^3` to `require-dev`; add to `suggest`
- `README.md` — document Insert integration in features list; remove from roadmap
- `CHANGELOG.md` — add `4.1.x-dev` entry

## Test plan

- [x] `DRUPAL_VERSION=11 make lint` — CSpell, PHPCS, PHPStan (level 7), Rector,
  Twig CS Fixer all pass
- [x] `DRUPAL_VERSION=11 make test` — 155 tests / 1,556 assertions pass
- [x] Manual: installed Insert module, created image field, configured Insert
  button — custom formatters appear in the Insert styles dropdown and render
  correctly on insertion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom formatters can now be exposed as Insert styles for image, file, and entity_reference fields when the Insert module is installed and enabled.

* **Documentation**
  * Updated CHANGELOG.md and README.md to document the new Insert module integration feature.

* **Tests**
  * Added comprehensive functional tests for Insert module integration, covering style registration, field-type filtering, and rendering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->